### PR TITLE
feat: 頂讓.tw rebrand homepage at /new

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "next-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000,
+      "autoPort": true
+    }
+  ]
+}

--- a/app/new/_components/Categories.tsx
+++ b/app/new/_components/Categories.tsx
@@ -1,0 +1,35 @@
+import Section from "./Section";
+import SectionTitle from "@/components/refactored/SectionTitle";
+import Category, {
+  type Category as CategoryType,
+} from "@/components/refactored/Category";
+import cn from "classnames";
+
+const categories: CategoryType[] = [
+  { ico: "餐", variant: "a", name: "餐飲", count: "412" },
+  { ico: "咖", variant: "b", name: "咖啡", count: "188" },
+  { ico: "飲", variant: "c", name: "手搖飲", count: "156" },
+  { ico: "火", variant: "default", name: "火鍋燒烤", count: "74" },
+  { ico: "美", variant: "a", name: "美容美髮", count: "96" },
+  { ico: "補", variant: "c", name: "補習教育", count: "41" },
+  { ico: "零", variant: "b", name: "零售", count: "132" },
+  { ico: "他", variant: "default", name: "其他", count: "88" },
+];
+
+export default function Categories() {
+  return (
+    <Section>
+      <SectionTitle num="05" title="依行業瀏覽" sub="— 從你熟悉的類型開始 —" />
+      <div
+        className={cn(
+          "grid gap-2",
+          "lg:grid-cols-8 md:grid-cols-4 grid-cols-3",
+        )}
+      >
+        {categories.map((category) => (
+          <Category key={category.name} category={category} />
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/app/new/_components/Districts.module.css
+++ b/app/new/_components/Districts.module.css
@@ -1,0 +1,35 @@
+.dist {
+  border: 1.5px solid var(--ink);
+  background: #fff;
+  border-radius: 4px;
+  padding: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+.dist:hover {
+  background: var(--paper-2);
+}
+.left {
+  font-family: var(--display);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1;
+}
+.left small {
+  display: block;
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--ink-2);
+  margin-top: 2px;
+  font-weight: 400;
+  letter-spacing: 0.1em;
+}
+.count {
+  font-family: var(--display);
+  font-size: 30px;
+  color: var(--accent);
+  font-weight: 700;
+  line-height: 1;
+}

--- a/app/new/_components/Districts.tsx
+++ b/app/new/_components/Districts.tsx
@@ -1,0 +1,52 @@
+import Section from "./Section";
+import SectionTitle from "@/components/refactored/SectionTitle";
+import styles from "./Districts.module.css";
+import cn from "classnames";
+
+const districts = [
+  { name: "大安區", en: "DA-AN", count: "124" },
+  { name: "信義區", en: "XINYI", count: "89" },
+  { name: "中山區", en: "ZHONGSHAN", count: "76" },
+  { name: "板橋區", en: "BANQIAO", count: "58" },
+  { name: "三重區", en: "SANCHONG", count: "41" },
+  { name: "新店區", en: "XINDIAN", count: "33" },
+  { name: "桃園市", en: "TAOYUAN", count: "112" },
+  { name: "台中西區", en: "TAICHUNG-W", count: "67" },
+];
+
+export default function Districts() {
+  return (
+    <Section variant="alt">
+      <SectionTitle
+        num="06"
+        title="熱門商圈"
+        sub="— 點擊看該區所有刊登 —"
+        more="看全部地區 →"
+      />
+      <div className={cn("grid gap-2", "lg:grid-cols-4 grid-cols-2")}>
+        {districts.map((district) => (
+          <District key={district.name} district={district} />
+        ))}
+      </div>
+    </Section>
+  );
+}
+
+export type District = {
+  name: string;
+  en: string;
+  count: string;
+};
+
+function District({ district }: { district: District }) {
+  const { name, en, count } = district;
+  return (
+    <div key={name} className={styles.dist}>
+      <div className={styles.left}>
+        {name}
+        <small>{en}</small>
+      </div>
+      <div className={styles.count}>{count}</div>
+    </div>
+  );
+}

--- a/app/new/_components/Faq.module.css
+++ b/app/new/_components/Faq.module.css
@@ -1,0 +1,50 @@
+.item {
+  display: flex;
+  flex-direction: column;
+}
+.question {
+  border: 1.5px solid var(--ink);
+  background: #fff;
+  border-radius: 4px;
+  padding: 12px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--hand);
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  color: var(--ink);
+
+  &:hover {
+    background: var(--accent);
+    color: #fff;
+    & .plus {
+      color: #fff;
+    }
+  }
+  &.open {
+    border-radius: 4px 4px 0 0;
+  }
+}
+
+.plus {
+  font-family: var(--display);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 0.5;
+  color: var(--accent);
+}
+.body {
+  border: 1.5px solid var(--ink);
+  border-top: 0;
+  background: var(--paper-2);
+  padding: 14px 16px;
+  font-family: var(--hand);
+  font-size: 13px;
+  color: var(--ink-2);
+  line-height: 1.55;
+  border-radius: 0 0 4px 4px;
+}

--- a/app/new/_components/Faq.tsx
+++ b/app/new/_components/Faq.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import Section from "./Section";
+import SectionTitle from "@/components/refactored/SectionTitle";
+import styles from "./Faq.module.css";
+import { cn } from "@/lib/utils";
+
+type FaqItem = { q: string; a: React.ReactNode };
+
+const items: FaqItem[] = [
+  {
+    q: "刊登要錢嗎？早鳥之後怎麼收？",
+    a: (
+      <>
+        <b>開站慶 · 前 3 個月完全免費刊登</b>（早鳥限定）。
+        <br />3
+        個月之後預計開始收取刊登費（金額確認後另行公告，早鳥用戶會優先通知）。
+        <br />
+        瀏覽永久免費 · 買賣雙方聯絡永久免費 ·
+        成交永久不抽成。早期上架的店主可享連續優惠。
+      </>
+    ),
+  },
+  { q: "頂讓金、押金、月租分別是什麼？怎麼算合理？", a: "（內容準備中）" },
+  { q: "買家怎麼確認店家的資訊是真的？", a: "（內容準備中）" },
+  { q: "房東不同意轉租怎麼辦？", a: "（內容準備中）" },
+  { q: "交接時設備清點怎麼做才不會後悔？", a: "（內容準備中）" },
+  { q: "遇到不誠實的買家 / 賣家怎麼辦？", a: "（內容準備中）" },
+];
+
+export default function Faq() {
+  const [openIndex, setOpenIndex] = useState<number | null>(0);
+
+  return (
+    <Section variant="alt">
+      <SectionTitle
+        num="11"
+        title="常見問題"
+        sub="— 第一次接手 / 頂出？這些先看 —"
+        more="完整 FAQ →"
+      />
+      <div className={"flex flex-col gap-2"}>
+        {items.map((item, i) => {
+          const isOpen = openIndex === i;
+          return (
+            <FaqItem
+              key={i}
+              item={item}
+              isOpen={isOpen}
+              onClick={() => setOpenIndex(isOpen ? null : i)}
+            />
+          );
+        })}
+      </div>
+    </Section>
+  );
+}
+
+function FaqItem({
+  item,
+  isOpen,
+  onClick,
+}: {
+  item: FaqItem;
+  isOpen: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div className={styles.item}>
+      <button
+        type="button"
+        className={cn(styles.question, isOpen && styles.open)}
+        onClick={onClick}
+        aria-expanded={isOpen}
+      >
+        <span>{item.q}</span>
+        <span className={styles.plus}>{isOpen ? "−" : "+"}</span>
+      </button>
+      {isOpen && <div className={styles.body}>{item.a}</div>}
+    </div>
+  );
+}

--- a/app/new/_components/FeaturedListings.module.css
+++ b/app/new/_components/FeaturedListings.module.css
@@ -1,0 +1,109 @@
+.listings {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+.card {
+  border: 1.5px solid var(--ink);
+  background: #fff;
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 3px 3px 0 var(--ink);
+}
+.ph {
+  aspect-ratio: 5 / 3;
+  border: 1.5px solid var(--ink);
+  border-left: 0;
+  border-right: 0;
+  border-top: 0;
+  background: repeating-linear-gradient(
+    135deg,
+    transparent 0 8px,
+    rgba(28, 26, 23, 0.08) 8px 9px
+  );
+  position: relative;
+  overflow: hidden;
+}
+.ph::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+    45deg,
+    transparent calc(50% - 0.5px),
+    var(--ink) calc(50% - 0.5px) calc(50% + 0.5px),
+    transparent calc(50% + 0.5px)
+  );
+  opacity: 0.15;
+  pointer-events: none;
+}
+.body {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.tags {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+.title {
+  font-family: var(--display);
+  font-size: 24px;
+  margin: 0;
+  font-weight: 700;
+  line-height: 1;
+}
+.meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-2);
+  line-height: 1.5;
+}
+.meta b {
+  color: var(--ink);
+  font-weight: 600;
+}
+.price {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-top: 6px;
+  border-top: 1.5px dashed var(--ink);
+}
+.price b {
+  font-family: var(--display);
+  font-size: 26px;
+  color: var(--accent);
+  font-weight: 700;
+  line-height: 1;
+}
+.rent {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-2);
+}
+.tabs {
+  display: flex;
+  justify-content: center;
+  margin-top: 18px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 900px) {
+  .listings {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 640px) {
+  .listings {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/new/_components/FeaturedListings.tsx
+++ b/app/new/_components/FeaturedListings.tsx
@@ -1,0 +1,81 @@
+import Section from "./Section";
+import SectionTitle from "@/components/refactored/SectionTitle";
+import Pill from "@/components/refactored/Pill";
+import styles from "./FeaturedListings.module.css";
+import StoreCard, {
+  type StoreCard as StoreCardType,
+} from "@/components/refactored/StoreCard";
+
+const featured: StoreCardType[] = [
+  {
+    tags: [
+      { label: "急售", variant: "warm" },
+      { label: "餐飲", variant: "default" },
+      { label: "含設備", variant: "mus" },
+    ],
+    title: "大安溫州街 · 老字號麵店",
+    meta: [
+      ["坪數", "12 坪"],
+      ["月租", "4.8 萬"],
+      ["已開", "8 年"],
+      ["客群", "學生 / 鄰里"],
+    ],
+    price: "NT$ 65 萬",
+    rent: "月租 / 押金已議",
+  },
+  {
+    tags: [
+      { label: "含證照", variant: "sage" },
+      { label: "飲料", variant: "default" },
+    ],
+    title: "中山赤峰 · 手搖飲品牌店",
+    meta: [
+      ["坪數", "8 坪"],
+      ["月租", "3.2 萬"],
+      ["已開", "3 年"],
+      ["設備", "全新整套"],
+    ],
+    price: "NT$ 45 萬",
+    rent: "押 2 / 含轉約",
+  },
+  {
+    tags: [
+      { label: "議價", variant: "mus" },
+      { label: "美容", variant: "default" },
+    ],
+    title: "板橋府中 · 美髮沙龍",
+    meta: [
+      ["坪數", "22 坪"],
+      ["月租", "6 萬"],
+      ["椅位", "4 椅"],
+      ["客群", "預約穩定"],
+    ],
+    price: "NT$ 120 萬",
+    rent: "含現有客戶",
+  },
+];
+
+export default function FeaturedListings() {
+  return (
+    <Section variant="alt">
+      <SectionTitle
+        num="04"
+        title="本週精選 / 急售"
+        sub="— 編輯挑選，含設備、地段佳 —"
+        more="看全部 412 間 →"
+      />
+      <div className={styles.listings}>
+        {featured.map((card, i) => (
+          <StoreCard key={i} card={card} />
+        ))}
+      </div>
+      <div className={styles.tabs}>
+        <Pill variant="solid">最新</Pill>
+        <Pill>急售</Pill>
+        <Pill>熱門收藏</Pill>
+        <Pill>編輯精選</Pill>
+        <Pill>100 萬以下</Pill>
+      </div>
+    </Section>
+  );
+}

--- a/app/new/_components/HeroSplit/HeroSplit.module.css
+++ b/app/new/_components/HeroSplit/HeroSplit.module.css
@@ -1,0 +1,204 @@
+.hero {
+  padding: 36px 28px 28px;
+  border-bottom: 1.5px solid var(--ink);
+  position: relative;
+}
+.kicker {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  margin-bottom: 10px;
+  text-align: center;
+}
+.title {
+  font-family: var(--display);
+  font-size: 80px;
+  line-height: 0.95;
+  margin: 0 0 8px;
+  font-weight: 700;
+  text-align: center;
+}
+.title em {
+  font-style: normal;
+  color: var(--accent);
+  text-decoration: underline wavy var(--accent);
+  text-underline-offset: 6px;
+}
+.sub {
+  font-family: var(--hand);
+  font-size: 15px;
+  color: var(--ink-2);
+  text-align: center;
+  margin: 0 auto 24px;
+  max-width: 560px;
+  line-height: 1.5;
+}
+.subAccent {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border: 2px solid var(--ink);
+  border-radius: 6px;
+  overflow: hidden;
+  background: #fff;
+}
+.col {
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: relative;
+  min-height: 340px;
+}
+.buy {
+  background: var(--paper-2);
+}
+.sell {
+  background: var(--ink);
+  color: var(--paper);
+  border-left: 1.5px solid var(--ink);
+}
+.sell * {
+  color: var(--paper);
+}
+.lab {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.lab::before {
+  content: "▸";
+  color: var(--accent);
+}
+.sell .lab {
+  color: var(--accent-3);
+}
+.sell .lab::before {
+  color: var(--accent-3);
+}
+.colTitle {
+  font-family: var(--display);
+  font-size: 42px;
+  margin: 0;
+  font-weight: 700;
+  line-height: 0.95;
+}
+.lead {
+  font-family: var(--hand);
+  font-size: 13px;
+  margin: 0;
+  line-height: 1.45;
+  color: var(--ink-2);
+}
+.sell .lead {
+  color: #cfc8b8;
+}
+.sell .lead b {
+  color: var(--accent-3);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 6px;
+}
+.formGrid2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.field {
+  border: 1.5px solid var(--ink);
+  background: #fff;
+  border-radius: 4px;
+  padding: 9px 12px;
+  font-family: var(--hand);
+  font-size: 13px;
+  color: var(--ink-2);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.field b {
+  color: var(--ink);
+  font-weight: 700;
+  min-width: 40px;
+  display: inline-block;
+}
+.fieldCar {
+  color: var(--muted);
+  flex: 1;
+}
+.field::after {
+  content: "▾";
+  color: var(--ink-2);
+  font-size: 10px;
+}
+.fieldInput::after {
+  content: "";
+}
+.sell .field {
+  background: #2a2723;
+  color: #cfc8b8;
+  border-color: var(--paper);
+}
+.sell .field b {
+  color: var(--paper);
+}
+
+.btn {
+  font-family: var(--hand);
+  font-weight: 700;
+  font-size: 14px;
+  border: 1.5px solid var(--ink);
+  padding: 8px 16px;
+  border-radius: 4px;
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 2px 2px 0 var(--ink);
+  display: inline-block;
+  cursor: pointer;
+  text-align: center;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease;
+}
+.btn:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 var(--ink);
+}
+.btnMus {
+  background: var(--accent-3);
+  color: var(--ink);
+}
+
+.row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+@media (max-width: 640px) {
+  .title {
+    font-size: 56px;
+  }
+  .split {
+    grid-template-columns: 1fr;
+  }
+  .sell {
+    border-left: 0;
+    border-top: 1.5px solid var(--ink);
+  }
+}

--- a/app/new/_components/HeroSplit/index.tsx
+++ b/app/new/_components/HeroSplit/index.tsx
@@ -1,0 +1,92 @@
+import Pill from "@/components/refactored/Pill";
+import styles from "./HeroSplit.module.css";
+
+export default function HeroSplit() {
+  return (
+    <section className={styles.hero}>
+      <div className={styles.kicker}>— 全台店面頂讓平台 · 真實刊登 —</div>
+      <h1 className={styles.title}>
+        找一間<em>準備好</em>的店
+        <br />
+        開門就營業
+      </h1>
+      <p className={styles.sub}>
+        買家直接接手已有客群、設備、營運的店面 · 賣家把心血交給合適的人。
+        <br />
+        <b className={styles.subAccent}>開站慶 · 前 3 個月免費刊登</b> ·
+        真實店家 · 買賣直接聯絡，沒有中間人。
+      </p>
+
+      <div className={styles.split}>
+        <div className={`${styles.col} ${styles.buy}`}>
+          <div className={styles.lab}>FOR BUYERS · 買家</div>
+          <h2 className={styles.colTitle}>
+            找店
+            <br />
+            接手就開張
+          </h2>
+          <p className={styles.lead}>
+            2,481 間真實刊登 · 含設備清單、客群分析、月營業額參考
+          </p>
+          <div className={styles.form}>
+            <div className={styles.field}>
+              <b>地區</b>
+              <span className={styles.fieldCar}>選擇縣市 / 行政區</span>
+            </div>
+            <div className={styles.field}>
+              <b>行業</b>
+              <span className={styles.fieldCar}>餐飲 · 飲料 · 零售 …</span>
+            </div>
+            <div className={styles.formGrid2}>
+              <div className={styles.field}>
+                <b>頂讓金</b>
+                <span className={styles.fieldCar}>不限</span>
+              </div>
+              <div className={styles.field}>
+                <b>坪數</b>
+                <span className={styles.fieldCar}>不限</span>
+              </div>
+            </div>
+            <span className={styles.btn}>瀏覽符合的店 →</span>
+          </div>
+          <div className={styles.row}>
+            <Pill>100 萬以下</Pill>
+            <Pill>含生財設備</Pill>
+            <Pill variant="warm">急售</Pill>
+            <Pill>捷運站旁</Pill>
+          </div>
+        </div>
+
+        <div className={`${styles.col} ${styles.sell}`}>
+          <div className={styles.lab}>FOR SELLERS · 賣家</div>
+          <h2 className={styles.colTitle}>
+            頂出
+            <br />
+            找到接手人
+          </h2>
+          <p className={styles.lead}>
+            5 分鐘填好就上架 · <b>前 3 個月免費（限早鳥）</b> · 買家直接聯絡你
+          </p>
+          <div className={styles.form}>
+            <div className={`${styles.field} ${styles.fieldInput}`}>
+              <b>店在</b>
+              <span className={styles.fieldCar}>輸入店面地址 ⌨︎</span>
+            </div>
+            <div className={styles.field}>
+              <b>類型</b>
+              <span className={styles.fieldCar}>選擇行業類別</span>
+            </div>
+            <span className={`${styles.btn} ${styles.btnMus}`}>
+              早鳥免費刊登 →
+            </span>
+          </div>
+          <div className={styles.row}>
+            <Pill variant="outlineLight">早鳥 0 元</Pill>
+            <Pill variant="outlineLight">本月新案 136</Pill>
+            <Pill variant="outlineLight">不抽成</Pill>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/new/_components/HowItWorks.module.css
+++ b/app/new/_components/HowItWorks.module.css
@@ -1,0 +1,90 @@
+.step {
+  border: 1.5px solid var(--paper);
+  background: transparent;
+  border-radius: 4px;
+  padding: 16px 14px 14px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.number {
+  position: absolute;
+  top: -14px;
+  left: -14px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  border: 2px solid var(--paper);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 18px;
+}
+.title {
+  font-family: var(--display);
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1;
+}
+.desc {
+  font-family: var(--hand);
+  font-size: 12px;
+  margin: 0;
+  line-height: 1.45;
+}
+.type {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  align-self: flex-start;
+  border: 1px solid var(--paper);
+  padding: 1px 5px;
+  border-radius: 2px;
+  margin-bottom: 2px;
+}
+.seller {
+  & .type {
+    color: var(--accent-3);
+    border-color: var(--accent-3);
+  }
+
+  & .number {
+    background: var(--accent-3);
+  }
+}
+.buyer {
+  & .type {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  & .number {
+    background: var(--accent);
+  }
+}
+
+.footer {
+  margin-top: 22px;
+  border: 1.5px dashed var(--paper);
+  padding: 14px 18px;
+  border-radius: 4px;
+  font-family: var(--hand);
+  font-size: 13px;
+  color: #cfc8b8;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 14px;
+}
+.footer b {
+  font-family: var(--display);
+  font-size: 20px;
+  color: var(--paper);
+  font-weight: 700;
+}

--- a/app/new/_components/HowItWorks.tsx
+++ b/app/new/_components/HowItWorks.tsx
@@ -1,0 +1,83 @@
+import Section from "./Section";
+import SectionTitle from "@/components/refactored/SectionTitle";
+import Pill from "@/components/refactored/Pill";
+import styles from "./HowItWorks.module.css";
+
+const buyerSteps: Step[] = [
+  {
+    number: 1,
+    type: "BUYER",
+    title: "搜尋 / 收藏",
+    desc: "用條件找店，收藏喜歡的。匿名瀏覽，不留資料。",
+  },
+  {
+    number: 2,
+    type: "BUYER",
+    title: "直接聯絡賣家",
+    desc: "看到喜歡的店？直接打電話 / LINE 給賣家，自己約看店、自己談價。",
+  },
+];
+
+const sellerSteps: Step[] = [
+  {
+    number: 1,
+    type: "SELLER",
+    title: "免費刊登（早鳥）",
+    desc: "5 分鐘填好店況、上傳照片。前 3 個月開站慶 0 元，當天上架。",
+  },
+  {
+    number: 2,
+    type: "SELLER",
+    title: "等買家來電",
+    desc: "有興趣的買家會直接聯絡你，平台不抽成、不收費。",
+  },
+];
+
+export default function HowItWorks() {
+  return (
+    <Section variant="dark">
+      <SectionTitle
+        num="07"
+        title="運作方式 · 簡單兩步"
+        sub="— 我們先把買賣雙方湊在一起，剩下你們自己談 —"
+        dark
+      />
+      <div className={"grid gap-4 relative grid-cols-2 lg:grid-cols-4"}>
+        {buyerSteps.map((step) => {
+          return <Step key={step.number} step={step} />;
+        })}
+        {sellerSteps.map((step) => {
+          return <Step key={step.number} step={step} />;
+        })}
+      </div>
+      <div className={styles.footer}>
+        <span>
+          <b>未來功能</b> · 之後會推出：站內訊息 NDA · 履約保證金 · 合約模板 ·
+          專人陪跑顧問
+        </span>
+        <Pill variant="outlineLight">敬請期待</Pill>
+      </div>
+    </Section>
+  );
+}
+
+type Step = {
+  number: number;
+  type: "BUYER" | "SELLER";
+  title: string;
+  desc: string;
+};
+
+function Step({ step }: { step: Step }) {
+  const { number, type, title, desc } = step;
+  return (
+    <div
+      className={`${styles.step} ${type === "BUYER" ? styles.buyer : styles.seller}`}
+    >
+      <span className={styles.number}>{number}</span>
+      <span className={styles.type}>{type}</span>
+      <h5 className={styles.title}>{title}</h5>
+      <p className={styles.desc}>{desc}</p>
+    </div>
+  );
+}

--- a/app/new/_components/LaunchBanner.module.css
+++ b/app/new/_components/LaunchBanner.module.css
@@ -1,0 +1,39 @@
+.launch {
+  background: var(--accent);
+  color: #fff;
+  padding: 8px 28px;
+  border-bottom: 1.5px solid var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  font-family: var(--hand);
+  font-size: 13px;
+}
+.launch b {
+  font-family: var(--display);
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1;
+}
+.tag {
+  background: #fff;
+  color: var(--accent);
+  border: 1.5px solid var(--ink);
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+.launch a {
+  color: #fff;
+  text-decoration: underline wavy var(--accent-3);
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+.soft {
+  opacity: 0.85;
+}

--- a/app/new/_components/LaunchBanner.tsx
+++ b/app/new/_components/LaunchBanner.tsx
@@ -1,0 +1,12 @@
+import styles from "./LaunchBanner.module.css";
+
+export default function LaunchBanner() {
+  return (
+    <div className={styles.launch}>
+      <span className={styles.tag}>EARLY BIRD</span>
+      <b>開站慶 · 前 3 個月免費刊登</b>
+      <span className={styles.soft}>— 早鳥用戶享連續優惠 ·</span>
+      <a>了解 →</a>
+    </div>
+  );
+}

--- a/app/new/_components/Logo.module.css
+++ b/app/new/_components/Logo.module.css
@@ -1,0 +1,37 @@
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--display);
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1;
+}
+.mark {
+  width: 34px;
+  height: 34px;
+  border: 2px solid var(--ink);
+  border-radius: 50%;
+  background: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: #fff;
+  font-weight: 700;
+}
+.text small {
+  display: block;
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--ink-2);
+  letter-spacing: 0.15em;
+  font-weight: 400;
+}
+.light {
+  color: var(--paper);
+}
+.light .text small {
+  color: #cfc8b8;
+}

--- a/app/new/_components/Logo.tsx
+++ b/app/new/_components/Logo.tsx
@@ -1,0 +1,18 @@
+import styles from "./Logo.module.css";
+
+export default function Logo({
+  tagline = "DING-RANG · since 2024",
+  light = false,
+}: {
+  tagline?: string;
+  light?: boolean;
+}) {
+  return (
+    <div className={`${styles.logo} ${light ? styles.light : ""}`}>
+      <span className={styles.mark}>頂</span>
+      <div className={styles.text}>
+        頂讓 . tw <small>{tagline}</small>
+      </div>
+    </div>
+  );
+}

--- a/app/new/_components/Section.module.css
+++ b/app/new/_components/Section.module.css
@@ -1,0 +1,18 @@
+.section {
+  padding: 32px 28px;
+  border-bottom: 1.5px solid var(--ink);
+  position: relative;
+}
+.alt {
+  background: var(--paper-2);
+}
+.dark {
+  background: var(--ink);
+  color: var(--paper);
+}
+.dark * {
+  color: var(--paper);
+}
+.trust {
+  padding: 24px 28px;
+}

--- a/app/new/_components/Section.tsx
+++ b/app/new/_components/Section.tsx
@@ -1,0 +1,16 @@
+import styles from "./Section.module.css";
+
+export type SectionVariant = "default" | "alt" | "dark" | "trust";
+
+export default function Section({
+  variant = "default",
+  children,
+}: {
+  variant?: SectionVariant;
+  children: React.ReactNode;
+}) {
+  const variantCls = variant === "default" ? "" : styles[variant];
+  return (
+    <section className={`${styles.section} ${variantCls}`}>{children}</section>
+  );
+}

--- a/app/new/_components/SellerCta.module.css
+++ b/app/new/_components/SellerCta.module.css
@@ -1,0 +1,62 @@
+.band {
+  border: 2px solid var(--ink);
+  border-radius: 6px;
+  background: var(--accent-3);
+  padding: 24px 28px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr auto;
+  gap: 20px;
+  align-items: center;
+  box-shadow: 5px 5px 0 var(--ink);
+  position: relative;
+
+  & h3 {
+    font-family: var(--display);
+    font-size: 38px;
+    margin: 0;
+    font-weight: 700;
+    line-height: 1;
+  }
+}
+
+.subline {
+  font-size: 24px;
+  color: var(--accent);
+}
+.band p {
+  font-family: var(--hand);
+  font-size: 13px;
+  margin: 6px 0 0;
+  color: var(--ink-2);
+  line-height: 1.5;
+}
+.stats {
+  display: flex;
+  gap: 18px;
+
+  & div {
+    font-family: var(--hand);
+    font-size: 11px;
+    color: var(--ink-2);
+    line-height: 1.3;
+  }
+
+  & b {
+    display: block;
+    font-family: var(--display);
+    font-size: 28px;
+    color: var(--ink);
+    font-weight: 700;
+    line-height: 1;
+  }
+}
+.unit {
+  font-family: var(--mono);
+  font-size: 13px;
+}
+
+@media (max-width: 900px) {
+  .band {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/new/_components/SellerCta.tsx
+++ b/app/new/_components/SellerCta.tsx
@@ -1,0 +1,43 @@
+import Section from "./Section";
+import styles from "./SellerCta.module.css";
+import Button from "@/components/refactored/Button";
+
+export default function SellerCta() {
+  return (
+    <Section>
+      <div className={styles.band}>
+        <div>
+          <h3>
+            想頂出你的店？
+            <br />
+            <span className={styles.subline}>前 3 個月免費 · 早鳥限定</span>
+          </h3>
+          <p>5 分鐘上架 · 開站慶免費刊登 · 買家直接聯絡你 · 永久不抽成交抽成</p>
+        </div>
+        <div className={styles.stats}>
+          <div>
+            <b>
+              3<small className={styles.unit}> 個月</small>
+            </b>
+            早鳥免費
+          </div>
+          <div>
+            <b>0%</b>成交抽成
+          </div>
+          <div>
+            <b>
+              5<small className={styles.unit}> 分鐘</small>
+            </b>
+            上架
+          </div>
+        </div>
+        <div className={"flex flex-col gap-2"}>
+          <Button>搶早鳥免費刊登 →</Button>
+          <Button variant="ghost" size="sm">
+            看刊登範例
+          </Button>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/app/new/_components/SiteFooter.module.css
+++ b/app/new/_components/SiteFooter.module.css
@@ -1,0 +1,72 @@
+.footer {
+  background: var(--ink);
+  color: var(--paper);
+  padding: 32px 28px 18px;
+  display: grid;
+  grid-template-columns: 1.3fr 1fr 1fr 1fr;
+  gap: 24px;
+}
+.footer h6 {
+  font-family: var(--display);
+  font-size: 22px;
+  margin: 0 0 8px;
+  color: var(--paper);
+  font-weight: 700;
+  line-height: 1;
+}
+.footer ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-family: var(--hand);
+  font-size: 13px;
+  color: #cfc8b8;
+  line-height: 1.9;
+}
+.brand p {
+  font-family: var(--hand);
+  font-size: 13px;
+  color: #cfc8b8;
+  line-height: 1.5;
+  margin: 8px 0;
+}
+.line {
+  border: 1.5px dashed var(--paper);
+  padding: 10px;
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: #cfc8b8;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+}
+.line b {
+  color: var(--paper);
+}
+.qr {
+  width: 50px;
+  height: 50px;
+  border: 1.5px solid var(--paper);
+  background:
+    repeating-linear-gradient(45deg, var(--paper) 0 3px, transparent 3px 5px),
+    repeating-linear-gradient(-45deg, var(--paper) 0 3px, transparent 3px 5px);
+}
+.legal {
+  grid-column: 1 / -1;
+  border-top: 1.5px dashed var(--paper);
+  margin-top: 18px;
+  padding-top: 14px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: #999083;
+  display: flex;
+  justify-content: space-between;
+}
+
+@media (max-width: 900px) {
+  .footer {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/app/new/_components/SiteFooter.tsx
+++ b/app/new/_components/SiteFooter.tsx
@@ -1,0 +1,61 @@
+import Logo from "./Logo";
+import styles from "./SiteFooter.module.css";
+
+export default function SiteFooter() {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.brand}>
+        <Logo tagline="DING-RANG" light />
+        <p>
+          全台最大店面頂讓平台。
+          <br />
+          真實刊登 · 履約保障 · 專人陪跑。
+        </p>
+        <div className={styles.line}>
+          <div className={styles.qr} />
+          <div>
+            客服 LINE
+            <br />
+            <b>@ding-rang</b>
+            <br />
+            09:00 – 21:00
+          </div>
+        </div>
+      </div>
+      <div>
+        <h6>找店</h6>
+        <ul>
+          <li>所有店面</li>
+          <li>地圖瀏覽</li>
+          <li>依行業</li>
+          <li>依地區</li>
+          <li>急售專區</li>
+        </ul>
+      </div>
+      <div>
+        <h6>頂出</h6>
+        <ul>
+          <li>早鳥免費刊登</li>
+          <li>刊登範例</li>
+          <li>定價指南</li>
+          <li>賣家後台</li>
+          <li>成交故事</li>
+        </ul>
+      </div>
+      <div>
+        <h6>關於 / 支援</h6>
+        <ul>
+          <li>關於我們</li>
+          <li>常見問題</li>
+          <li>聯絡客服</li>
+          <li>服務條款</li>
+          <li>隱私政策</li>
+        </ul>
+      </div>
+      <div className={styles.legal}>
+        <span>© 2026 頂讓 . tw · ding-rang.tw</span>
+        <span>made in Taipei · 北市商字第 12345678 號</span>
+      </div>
+    </footer>
+  );
+}

--- a/app/new/_components/SiteNav.tsx
+++ b/app/new/_components/SiteNav.tsx
@@ -1,0 +1,42 @@
+import Logo from "./Logo";
+import Pill from "@/components/refactored/Pill";
+import Button from "@/components/refactored/Button";
+import Link from "@/components/refactored/Link";
+import { cn } from "@/lib/utils";
+
+const navLinks = ["我要找店", "我要頂出", "頂讓指南", "成交故事", "常見問題"];
+
+export default function SiteNav() {
+  return (
+    <nav
+      className={cn(
+        "flex items-center justify-between",
+        "border-b-[1.5px] border-solid border-[var(--ink)]",
+        "px-7 py-3.5",
+        "bg-[var(--paper)]",
+      )}
+    >
+      <Logo />
+      <ul
+        className={cn(
+          "text-sm font-[var(--hand)]",
+          "hidden sm:flex gap-[22px]",
+          "m-0 p-0 ",
+          "list-none",
+        )}
+      >
+        {navLinks.map((l) => (
+          <Link href={`/${l.toLowerCase()}`} key={l}>
+            {l}
+          </Link>
+        ))}
+      </ul>
+      <div className="flex items-center gap-2">
+        <Pill>登入</Pill>
+        <Button variant="mus" className="px-2 py-1 text-xs">
+          + 限時免費刊登
+        </Button>
+      </div>
+    </nav>
+  );
+}

--- a/app/new/_components/Stories.module.css
+++ b/app/new/_components/Stories.module.css
@@ -1,0 +1,85 @@
+.stories {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.story {
+  border: 1.5px solid var(--ink);
+  background: #fff;
+  border-radius: 4px;
+  padding: 18px;
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 14px;
+  align-items: flex-start;
+  position: relative;
+}
+.av {
+  width: 90px;
+  aspect-ratio: 1;
+  border: 1.5px solid var(--ink);
+  border-radius: 50%;
+  background: repeating-linear-gradient(
+    135deg,
+    var(--paper-2) 0 8px,
+    var(--paper-3) 8px 9px
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--ink-2);
+  text-align: center;
+  padding: 6px;
+}
+.who {
+  font-family: var(--display);
+  font-size: 22px;
+  margin: 0 0 2px;
+  font-weight: 700;
+  line-height: 1;
+}
+.who small {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-2);
+  font-weight: 400;
+  margin-top: 3px;
+  letter-spacing: 0.05em;
+}
+.story p {
+  font-family: var(--hand);
+  font-size: 13px;
+  margin: 6px 0 0;
+  line-height: 1.55;
+  color: var(--ink-2);
+}
+.quote {
+  font-family: var(--display);
+  font-size: 50px;
+  color: var(--accent);
+  position: absolute;
+  top: 6px;
+  right: 14px;
+  line-height: 1;
+  font-weight: 700;
+}
+.stat {
+  font-family: var(--mono);
+  font-size: 10px;
+  background: var(--paper-2);
+  border: 1px solid var(--ink);
+  padding: 3px 8px;
+  border-radius: 2px;
+  display: inline-block;
+  margin-top: 8px;
+  color: var(--ink-2);
+}
+
+@media (max-width: 900px) {
+  .stories {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/new/_components/Stories.tsx
+++ b/app/new/_components/Stories.tsx
@@ -1,0 +1,49 @@
+import Section from "./Section";
+import SectionTitle from "@/components/refactored/SectionTitle";
+import styles from "./Stories.module.css";
+
+const stories = [
+  {
+    who: "陳先生 · 36 歲",
+    role: "原行銷主管 → 接手永和早餐店",
+    quote:
+      "原本想自己開，光是租店面 + 設備就吃掉一半預算。在這邊接手了已經穩定 6 年的早餐店，第一個月就有現金流，不用從零開始教熟客。",
+    stat: "接手金 NT$ 55 萬 · 32 天完成",
+  },
+  {
+    who: "林老闆 · 58 歲",
+    role: "頂出大安麵店 → 退休",
+    quote:
+      "開了 14 年，孩子不接，本來想直接收掉。顧問幫我估價、拍照、寫故事，3 週就找到合適的接手人 — 重點是他真的會用心做下去。",
+    stat: "頂出 NT$ 88 萬 · 21 天成交",
+  },
+];
+
+export default function Stories() {
+  return (
+    <Section variant="alt">
+      <SectionTitle
+        num="09"
+        title="成交故事"
+        sub="— 真實接手人 / 頂出人的回饋 —"
+        more="看更多故事 →"
+      />
+      <div className={styles.stories}>
+        {stories.map((s, i) => (
+          <div key={i} className={styles.story}>
+            <div className={styles.av}>頭像 / 店面合照</div>
+            <div>
+              <div className={styles.who}>
+                {s.who}
+                <small>{s.role}</small>
+              </div>
+              <p>{s.quote}</p>
+              <span className={styles.stat}>{s.stat}</span>
+              <span className={styles.quote}>&ldquo;</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/app/new/_components/TrustBar.module.css
+++ b/app/new/_components/TrustBar.module.css
@@ -1,0 +1,49 @@
+.trust {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border: 1.5px solid var(--ink);
+  border-radius: 4px;
+  background: #fff;
+  overflow: hidden;
+}
+.item {
+  padding: 18px;
+  text-align: center;
+  border-right: 1.5px dashed var(--ink);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.item:last-child {
+  border-right: 0;
+}
+.item b {
+  font-family: var(--display);
+  font-size: 42px;
+  color: var(--ink);
+  font-weight: 700;
+  line-height: 1;
+}
+.item b em {
+  font-style: normal;
+  color: var(--accent);
+}
+.item span {
+  font-family: var(--hand);
+  font-size: 12px;
+  color: var(--ink-2);
+}
+.unit {
+  font-family: var(--mono);
+  font-size: 14px;
+}
+
+@media (max-width: 640px) {
+  .trust {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .item:nth-child(2) {
+    border-right: 0;
+  }
+}

--- a/app/new/_components/TrustBar.tsx
+++ b/app/new/_components/TrustBar.tsx
@@ -1,0 +1,31 @@
+import Section from "./Section";
+import styles from "./TrustBar.module.css";
+
+export default function TrustBar() {
+  return (
+    <Section variant="trust">
+      <div className={styles.trust}>
+        <div className={styles.item}>
+          <b>2,481</b>
+          <span>目前刊登店數</span>
+        </div>
+        <div className={styles.item}>
+          <b>
+            <em>136</em>
+          </b>
+          <span>本月新上架</span>
+        </div>
+        <div className={styles.item}>
+          <b>
+            0<small className={styles.unit}> 元</small>
+          </b>
+          <span>早鳥刊登費 (前 3 個月)</span>
+        </div>
+        <div className={styles.item}>
+          <b>0%</b>
+          <span>平台抽成</span>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/app/new/_components/WhyUs.module.css
+++ b/app/new/_components/WhyUs.module.css
@@ -1,0 +1,61 @@
+.why {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+.item {
+  border: 1.5px solid var(--ink);
+  background: #fff;
+  border-radius: 4px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+
+  & h5 {
+    font-family: var(--display);
+    font-size: 24px;
+    margin: 0;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  & p {
+    font-family: var(--hand);
+    font-size: 12px;
+    margin: 0;
+    color: var(--ink-2);
+    line-height: 1.5;
+  }
+}
+.ico {
+  width: 40px;
+  height: 40px;
+  border: 1.5px solid var(--ink);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 24px;
+}
+.icoA {
+  background: var(--accent);
+  color: #fff;
+}
+.icoB {
+  background: var(--accent-2);
+  color: #fff;
+}
+.icoC {
+  background: var(--accent-3);
+  color: var(--ink);
+}
+
+@media (max-width: 900px) {
+  .why {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/new/_components/WhyUs.tsx
+++ b/app/new/_components/WhyUs.tsx
@@ -1,0 +1,59 @@
+import Section from "./Section";
+import SectionTitle from "@/components/refactored/SectionTitle";
+import styles from "./WhyUs.module.css";
+
+const items: WhyUsItem[] = [
+  {
+    ico: "✓",
+    variant: "A",
+    title: "真實店家",
+    desc: "每筆刊登都需要店面照片與聯絡資料，杜絕假廣告與釣魚仲介。",
+  },
+  {
+    ico: "$",
+    variant: "B",
+    title: "早鳥免費 · 永久不抽成",
+    desc: "開站慶前 3 個月刊登 0 元；瀏覽永久免費、聯絡永久免費。買賣雙方直接談，平台不抽任何成交抽成。",
+  },
+  {
+    ico: "直",
+    variant: "C",
+    title: "直接聯絡",
+    desc: "看到喜歡的店，電話 / LINE 直接聯絡賣家，沒有中間人轉手、沒有資訊延遲。",
+  },
+];
+
+export default function WhyUs() {
+  return (
+    <Section>
+      <SectionTitle
+        num="08"
+        title="為什麼用我們"
+        sub="— 不是分類廣告板，是有人陪跑的平台 —"
+      />
+      <div className={"grid gap-4 lg:grid-cols-3 grid-cols-1"}>
+        {items.map((item) => {
+          return <WhyUsItem key={item.ico} item={item} />;
+        })}
+      </div>
+    </Section>
+  );
+}
+
+type WhyUsItem = {
+  ico: string;
+  variant: "A" | "B" | "C";
+  title: string;
+  desc: string;
+};
+
+function WhyUsItem({ item }: { item: WhyUsItem }) {
+  const { ico, variant, title, desc } = item;
+  return (
+    <div className={styles.item}>
+      <div className={`${styles.ico} ${styles[`ico${variant}`]}`}>{ico}</div>
+      <h5>{title}</h5>
+      <p>{desc}</p>
+    </div>
+  );
+}

--- a/app/new/page.module.css
+++ b/app/new/page.module.css
@@ -1,0 +1,31 @@
+.root {
+  --ink: #1c1a17;
+  --ink-2: #3a3631;
+  --paper: #f6f2e9;
+  --paper-2: #ece5d3;
+  --paper-3: #e0d6bc;
+  --accent: #d94a2a;
+  --accent-2: #2a6f4d;
+  --accent-3: #e6b833;
+  --muted: #8a8278;
+  --hand: var(--font-kalam), "Noto Sans TC", sans-serif;
+  --display: var(--font-caveat), "Noto Sans TC", sans-serif;
+  --note: var(--font-gloria), var(--font-kalam), sans-serif;
+  --mono: var(--font-jetbrains), monospace;
+
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--hand);
+  min-height: 100vh;
+}
+
+.root *,
+.root *::before,
+.root *::after {
+  box-sizing: border-box;
+}
+
+.frame {
+  max-width: 1200px;
+  margin: 0 auto;
+}

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next";
+import {
+  Caveat,
+  Kalam,
+  Gloria_Hallelujah,
+  JetBrains_Mono,
+} from "next/font/google";
+import styles from "./page.module.css";
+import LaunchBanner from "./_components/LaunchBanner";
+import SiteNav from "./_components/SiteNav";
+import HeroSplit from "./_components/HeroSplit";
+import TrustBar from "./_components/TrustBar";
+import FeaturedListings from "./_components/FeaturedListings";
+import Categories from "./_components/Categories";
+import Districts from "./_components/Districts";
+import HowItWorks from "./_components/HowItWorks";
+import WhyUs from "./_components/WhyUs";
+import Stories from "./_components/Stories";
+import SellerCta from "./_components/SellerCta";
+import Faq from "./_components/Faq";
+import SiteFooter from "./_components/SiteFooter";
+
+const caveat = Caveat({
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+  variable: "--font-caveat",
+  display: "swap",
+});
+const kalam = Kalam({
+  subsets: ["latin"],
+  weight: ["300", "400", "700"],
+  variable: "--font-kalam",
+  display: "swap",
+});
+const gloria = Gloria_Hallelujah({
+  subsets: ["latin"],
+  weight: ["400"],
+  variable: "--font-gloria",
+  display: "swap",
+});
+const jetbrains = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "600"],
+  variable: "--font-jetbrains",
+  display: "swap",
+});
+
+export const metadata: Metadata = {
+  title: "頂讓.tw — 找一間準備好的店",
+  description:
+    "全台店面頂讓平台。買家直接接手已有客群、設備、營運的店面；賣家把心血交給合適的人。早鳥前 3 個月免費刊登，永久不抽成。",
+};
+
+export default function NewHomePage() {
+  const fontVars = `${caveat.variable} ${kalam.variable} ${gloria.variable} ${jetbrains.variable}`;
+
+  return (
+    <div className={`${styles.root} ${fontVars}`}>
+      <LaunchBanner />
+      <SiteNav />
+      <div className={styles.frame}>
+        <HeroSplit />
+        <TrustBar />
+        <FeaturedListings />
+        <Categories />
+        <Districts />
+        <HowItWorks />
+        <WhyUs />
+        <Stories />
+        <SellerCta />
+        <Faq />
+      </div>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/components/refactored/Button.module.css
+++ b/components/refactored/Button.module.css
@@ -1,0 +1,37 @@
+.btn {
+  font-family: var(--hand);
+  font-weight: 700;
+  font-size: 14px;
+  border: 1.5px solid var(--ink);
+  padding: 8px 16px;
+  border-radius: 4px;
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 2px 2px 0 var(--ink);
+  display: inline-block;
+  cursor: pointer;
+  text-align: center;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease;
+  &.mus {
+    background: var(--accent-3);
+    color: var(--ink);
+  }
+  &.ghost {
+    background: #fff;
+    color: var(--ink);
+    box-shadow: none;
+  }
+}
+.btn:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+.md {
+  padding: 8px 16px;
+}
+.sm {
+  padding: 5px 10px;
+}

--- a/components/refactored/Button.tsx
+++ b/components/refactored/Button.tsx
@@ -1,0 +1,24 @@
+import styles from "./Button.module.css";
+import { cn } from "@/lib/utils";
+
+export type ButtonVariant = "default" | "mus" | "ghost";
+
+export default function Button({
+  variant = "default",
+  size = "md",
+  children,
+  className,
+}: {
+  variant?: ButtonVariant;
+  size?: "md" | "sm";
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const variantCls = variant === "default" ? "" : styles[variant];
+  const sizeCls = size === "md" ? styles.md : styles.sm;
+  return (
+    <button className={cn(styles.btn, variantCls, sizeCls, className)}>
+      {children}
+    </button>
+  );
+}

--- a/components/refactored/Category.module.css
+++ b/components/refactored/Category.module.css
@@ -1,0 +1,57 @@
+.category {
+  border: 1.5px solid var(--ink);
+  background: #fff;
+  border-radius: 4px;
+  padding: 14px 6px;
+  text-align: center;
+  font-family: var(--hand);
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease;
+
+  & b {
+    font-weight: 700;
+    display: block;
+  }
+
+  & span {
+    font-family: var(--mono);
+    font-size: 9px;
+    color: var(--ink-2);
+  }
+}
+.category:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 2px 2px 0 var(--ink);
+}
+.ico {
+  width: 34px;
+  height: 34px;
+  border: 1.5px solid var(--ink);
+  border-radius: 6px;
+  background: var(--paper-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--display);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--ink);
+}
+.icoA {
+  background: var(--accent);
+  color: #fff;
+}
+.icoB {
+  background: var(--accent-2);
+  color: #fff;
+}
+.icoC {
+  background: var(--accent-3);
+}

--- a/components/refactored/Category.tsx
+++ b/components/refactored/Category.tsx
@@ -1,0 +1,27 @@
+import styles from "./Category.module.css";
+
+type CategoryVariant = "a" | "b" | "c" | "default";
+
+export type Category = {
+  ico: string;
+  variant: CategoryVariant;
+  name: string;
+  count: string;
+};
+const variantClass: Record<CategoryVariant, string> = {
+  a: styles.icoA,
+  b: styles.icoB,
+  c: styles.icoC,
+  default: "",
+};
+
+export default function Category({ category }: { category: Category }) {
+  const { ico, variant, name, count } = category;
+  return (
+    <div key={name} className={styles.category}>
+      <div className={`${styles.ico} ${variantClass[variant]}`}>{ico}</div>
+      <b>{name}</b>
+      <span>{count}</span>
+    </div>
+  );
+}

--- a/components/refactored/Link.module.css
+++ b/components/refactored/Link.module.css
@@ -1,0 +1,8 @@
+.link {
+  color: var(--ink);
+  text-decoration: none;
+  cursor: pointer;
+}
+.link:hover {
+  text-decoration: underline wavy var(--accent);
+}

--- a/components/refactored/Link.tsx
+++ b/components/refactored/Link.tsx
@@ -1,0 +1,15 @@
+import styles from "./Link.module.css";
+
+export default function Link({
+  children,
+  href,
+}: {
+  children: React.ReactNode;
+  href: string;
+}) {
+  return (
+    <a className={styles.link} href={href}>
+      {children}
+    </a>
+  );
+}

--- a/components/refactored/Pill.module.css
+++ b/components/refactored/Pill.module.css
@@ -1,0 +1,31 @@
+.pill {
+  font-family: var(--hand);
+  font-size: 13px;
+  border: 1.5px solid var(--ink);
+  padding: 5px 12px;
+  border-radius: 99px;
+  background: #fff;
+  color: var(--ink);
+  display: inline-block;
+}
+.solid {
+  background: var(--ink);
+  color: var(--paper);
+}
+.warm {
+  background: var(--accent);
+  color: #fff;
+}
+.sage {
+  background: var(--accent-2);
+  color: #fff;
+}
+.mus {
+  background: var(--accent-3);
+  color: var(--ink);
+}
+.outlineLight {
+  background: transparent;
+  border-color: var(--paper);
+  color: var(--paper);
+}

--- a/components/refactored/Pill.tsx
+++ b/components/refactored/Pill.tsx
@@ -1,0 +1,20 @@
+import styles from "./Pill.module.css";
+
+export type PillVariant =
+  | "default"
+  | "warm"
+  | "sage"
+  | "mus"
+  | "solid"
+  | "outlineLight";
+
+export default function Pill({
+  variant = "default",
+  children,
+}: {
+  variant?: PillVariant;
+  children: React.ReactNode;
+}) {
+  const variantCls = variant === "default" ? "" : styles[variant];
+  return <span className={`${styles.pill} ${variantCls}`}>{children}</span>;
+}

--- a/components/refactored/SectionTitle.module.css
+++ b/components/refactored/SectionTitle.module.css
@@ -1,0 +1,49 @@
+.wrap {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 18px;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.left {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.num {
+  font-family: var(--mono);
+  font-size: 11px;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 3px 8px;
+  border-radius: 2px;
+  letter-spacing: 0.1em;
+}
+.numDark {
+  background: var(--paper);
+  color: var(--ink);
+}
+.h {
+  font-family: var(--display);
+  font-size: 36px;
+  margin: 0;
+  font-weight: 700;
+  line-height: 1;
+}
+.sub {
+  font-family: var(--note);
+  font-size: 14px;
+  color: var(--ink-2);
+}
+.subDark {
+  color: #cfc8b8;
+}
+.more {
+  font-family: var(--hand);
+  font-size: 13px;
+  color: var(--ink);
+  text-decoration: underline wavy var(--accent);
+  cursor: pointer;
+}

--- a/components/refactored/SectionTitle.tsx
+++ b/components/refactored/SectionTitle.tsx
@@ -1,0 +1,29 @@
+import styles from "./SectionTitle.module.css";
+import cn from "classnames";
+
+export default function SectionTitle({
+  num,
+  title,
+  sub,
+  more,
+  dark = false,
+}: {
+  num: string;
+  title: string;
+  sub?: string;
+  more?: string;
+  dark?: boolean;
+}) {
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.left}>
+        <span className={cn(styles.num, dark && styles.numDark)}>{num}</span>
+        <h3 className={styles.h}>{title}</h3>
+        {sub && (
+          <span className={cn(styles.sub, dark && styles.subDark)}>{sub}</span>
+        )}
+      </div>
+      {more && <a className={styles.more}>{more}</a>}
+    </div>
+  );
+}

--- a/components/refactored/StoreCard.module.css
+++ b/components/refactored/StoreCard.module.css
@@ -1,0 +1,81 @@
+.card {
+  border: 1.5px solid var(--ink);
+  background: #fff;
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 3px 3px 0 var(--ink);
+}
+.card:hover {
+  box-shadow: 4px 4px 0 var(--accent);
+  transform: translate(-1px, -1px);
+}
+
+.placeholderPhoto {
+  aspect-ratio: 5 / 3;
+  border: 1.5px solid var(--ink);
+  border-left: 0;
+  border-right: 0;
+  border-top: 0;
+  background: repeating-linear-gradient(
+    135deg,
+    transparent 0 8px,
+    rgba(28, 26, 23, 0.08) 8px 9px
+  );
+  position: relative;
+  overflow: hidden;
+}
+.placeholderPhoto::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+    45deg,
+    transparent calc(50% - 0.5px),
+    var(--ink) calc(50% - 0.5px) calc(50% + 0.5px),
+    transparent calc(50% + 0.5px)
+  );
+  opacity: 0.15;
+  pointer-events: none;
+}
+
+.title {
+  font-family: var(--display);
+  font-size: 24px;
+  margin: 0;
+  font-weight: 700;
+  line-height: 1;
+}
+.meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-2);
+  line-height: 1.5;
+}
+.meta b {
+  color: var(--ink);
+  font-weight: 600;
+}
+.price {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-top: 12px;
+  border-top: 1.5px dashed var(--ink);
+}
+.price b {
+  font-family: var(--display);
+  font-size: 26px;
+  color: var(--accent);
+  font-weight: 700;
+  line-height: 1;
+}
+.rent {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-2);
+}

--- a/components/refactored/StoreCard.tsx
+++ b/components/refactored/StoreCard.tsx
@@ -1,0 +1,39 @@
+import styles from "./StoreCard.module.css";
+import Pill, { type PillVariant } from "@/components/refactored/Pill";
+
+export type StoreCard = {
+  tags: { label: string; variant: PillVariant }[];
+  title: string;
+  meta: [string, string][];
+  price: string;
+  rent: string;
+};
+
+export default function StoreCard({ card }: { card: StoreCard }) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.placeholderPhoto} />
+      <div className={"p-3.5 flex flex-col gap-2"}>
+        <div className={"flex flex-wrap gap-1.5"}>
+          {card.tags.map((t) => (
+            <Pill key={t.label} variant={t.variant}>
+              {t.label}
+            </Pill>
+          ))}
+        </div>
+        <h4 className={styles.title}>{card.title}</h4>
+        <div className={styles.meta}>
+          {card.meta.map(([k, v]) => (
+            <div key={k}>
+              <b>{k}</b> {v}
+            </div>
+          ))}
+        </div>
+        <div className={styles.price}>
+          <b>{card.price}</b>
+          <span className={styles.rent}>{card.rent}</span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a full rebrand homepage at `/new` implementing the 頂讓.tw V4 MVP design (方向4 · dual-audience) from the Claude Design handoff bundle
- Extracts reusable design-system atoms into `components/refactored/` (`Button`, `Pill`, `SectionTitle`, `StoreCard`, `Category`, `Link`)
- Each page section is a self-contained component with a co-located CSS module under `app/new/_components/`

## What's included

**Page sections (top → bottom)**
- `LaunchBanner` — early-bird promo strip
- `SiteNav` — logo + nav links + login/CTA (Tailwind-composed)
- `HeroSplit` — 50/50 buyer (paper bg) / seller (dark bg) split with search forms
- `TrustBar` — 4 trust stats (listings / new this month / free listing / 0% commission)
- `FeaturedListings` — 3 store cards with placeholder images, tags, meta, price
- `Categories` — 8 industry tiles
- `Districts` — 8 popular area tiles
- `HowItWorks` — dark section, 4 alternating buyer/seller steps
- `WhyUs` — 3 value-prop cards
- `Stories` — 2 testimonial cards
- `SellerCta` — mustard CTA band
- `Faq` — accordion (client component), first item open by default
- `SiteFooter` — 4-column footer with LINE QR placeholder + legal

**Design system**
- CSS variable tokens (`--ink`, `--paper`, `--accent` family) defined on `.root`, cascading to all children
- Paper/ink hand-drawn aesthetic: 1.5px borders, dashed dividers, offset shadows, wavy underlines
- Fonts loaded via `next/font`: Caveat (display), Kalam (body), Gloria Hallelujah (notes), JetBrains Mono

## Reviewer notes

- Card images are diagonal-stripe placeholders; real assets to be swapped in later
- Wireframe-only artifacts (design annotations, browser chrome, tweaks panel) intentionally omitted
- Basic mobile stacking breakpoints included; full responsive pass deferred to the separate mobile design file
- All mock data is hardcoded inline — wiring to real data is a follow-up

## Test plan

- [ ] `npm run dev` → visit `/new`, verify all 13 sections render
- [ ] Click FAQ questions — accordion toggles open/closed
- [ ] Scroll to bottom — footer ends flush with no trailing space
- [ ] Resize to <640px — hero split stacks, nav links hide, trust bar becomes 2-column
- [ ] `npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)