### PR TITLE
feat(store-list): wire real Firestore data to new/store-list page

### DIFF
--- a/app/new/store-list/_components/ActiveFilters.tsx
+++ b/app/new/store-list/_components/ActiveFilters.tsx
@@ -6,6 +6,7 @@ import {
   tagAtom,
   amountFilterAtom,
   categoryAtom,
+  type FilterKey,
 } from "@/atoms/SearchFilterAtom";
 import { STORE_TAGS } from "@/constant/storeTags";
 import styles from "./ActiveFilters.module.css";
@@ -27,11 +28,11 @@ export default function ActiveFilters() {
       key: "amountFilter",
       label: amountFilter.label as string,
     },
-  ].filter(Boolean) as { key: string; label: string }[];
+  ].filter(Boolean) as { key: FilterKey; label: string }[];
 
   if (filters.length === 0) return null;
 
-  function handleRemove(key: string) {
+  function handleRemove(key: FilterKey) {
     if (key === "city") setCity(undefined);
     if (key === "tag") setTag(undefined);
     if (key === "category") setCategory(undefined);

--- a/app/new/store-list/_components/Breadcrumbs.tsx
+++ b/app/new/store-list/_components/Breadcrumbs.tsx
@@ -1,20 +1,15 @@
 import styles from "./Breadcrumbs.module.css";
 
-export default function Breadcrumbs() {
+export default function Breadcrumbs({ count }: { count: number }) {
   return (
     <div className={styles.crumbs}>
       <div>
         <div className={styles.trail}>
-          <a href="/new">首頁</a> / <a href="/new/store-list">我要找店</a> /
-          台北市 · 餐飲
+          <a href="/new">首頁</a> / <a href="/new/store-list">我要找店</a>
         </div>
         <h2 className={styles.title}>
-          台北市 · 餐飲店面 <em>共 412 間</em>
+          我要找店 <em>共 {count} 間</em>
         </h2>
-      </div>
-      <div className={styles.stat}>
-        <b className={styles.statNum}>136</b>
-        本月新上架
       </div>
     </div>
   );

--- a/app/new/store-list/_components/ResultsArea.tsx
+++ b/app/new/store-list/_components/ResultsArea.tsx
@@ -67,8 +67,16 @@ function storeToCard(store: Store): StoreCardType {
   };
 }
 
+function sortStores(stores: Store[], sort: string): Store[] {
+  const sorted = [...stores];
+  if (sort === "price-asc") return sorted.sort((a, b) => a.price - b.price);
+  if (sort === "price-desc") return sorted.sort((a, b) => b.price - a.price);
+  return sorted.sort((a, b) => b.updateTime.getTime() - a.updateTime.getTime());
+}
+
 export default function ResultsArea({ stores }: { stores: Store[] }) {
   const [sort, setSort] = useState("newest");
+  const sortedStores = sortStores(stores, sort);
 
   return (
     <div className={styles.area}>
@@ -87,7 +95,7 @@ export default function ResultsArea({ stores }: { stores: Store[] }) {
       </div>
 
       <div className={styles.grid}>
-        {stores.map((store) => (
+        {sortedStores.map((store) => (
           <StoreCard key={store.id} card={storeToCard(store)} />
         ))}
       </div>

--- a/app/new/store-list/_components/ResultsArea.tsx
+++ b/app/new/store-list/_components/ResultsArea.tsx
@@ -4,14 +4,18 @@ import { useState } from "react";
 import styles from "./ResultsArea.module.css";
 import StoreCard, {
   type StoreCard as StoreCardType,
-  type RibbonVariant,
 } from "@/components/refactored/StoreCard";
 import Dropdown, {
   type DropdownOption,
 } from "@/components/refactored/Dropdown";
 import { type PillVariant } from "@/components/refactored/Pill";
-import { type Store, STORE_TAG } from "@/types";
+import { type Store } from "@/types";
 import { STORE_CATEGORIES } from "@/constant/storeType";
+import {
+  TAG_DISPLAY,
+  RIBBON_DISPLAY,
+  RIBBON_PRIORITY,
+} from "@/constant/storeDisplay";
 
 const sortOptions: DropdownOption[] = [
   { label: "頂讓金：低 → 高", value: "price-asc" },
@@ -19,30 +23,11 @@ const sortOptions: DropdownOption[] = [
   { label: "最新上架", value: "newest" },
 ];
 
-const TAG_MAP: Record<string, { label: string; variant: PillVariant }> = {
-  [STORE_TAG.EMERGENCY]: { label: "急售", variant: "warm" },
-  [STORE_TAG.HOT]: { label: "熱門", variant: "default" },
-  [STORE_TAG.CHEAP]: { label: "划算", variant: "default" },
-  [STORE_TAG.RECOMMENDED]: { label: "精選", variant: "sage" },
-};
-
-const RIBBON_MAP: Record<string, { label: string; variant: RibbonVariant }> = {
-  [STORE_TAG.EMERGENCY]: { label: "急售", variant: "default" },
-  [STORE_TAG.RECOMMENDED]: { label: "精選", variant: "sage" },
-  [STORE_TAG.CHEAP]: { label: "划算", variant: "mus" },
-};
-
-const RIBBON_PRIORITY = [
-  STORE_TAG.EMERGENCY,
-  STORE_TAG.RECOMMENDED,
-  STORE_TAG.CHEAP,
-];
-
 function storeToCard(store: Store): StoreCardType {
   const tags = store.tags ?? [];
 
   const ribbonTag = RIBBON_PRIORITY.find((tag) => tags.includes(tag));
-  const ribbon = ribbonTag ? RIBBON_MAP[ribbonTag] : undefined;
+  const ribbon = ribbonTag ? RIBBON_DISPLAY[ribbonTag] : undefined;
 
   const categoryEntry = STORE_CATEGORIES.find(
     (cat) => cat.key === store.category,
@@ -52,7 +37,7 @@ function storeToCard(store: Store): StoreCardType {
   const tagPills = [
     ...tags.map(
       (tag) =>
-        TAG_MAP[tag] ?? { label: tag, variant: "default" as PillVariant },
+        TAG_DISPLAY[tag] ?? { label: tag, variant: "default" as PillVariant },
     ),
     ...(categoryLabel
       ? [{ label: categoryLabel, variant: "default" as PillVariant }]

--- a/app/new/store-list/_components/ResultsArea.tsx
+++ b/app/new/store-list/_components/ResultsArea.tsx
@@ -4,10 +4,14 @@ import { useState } from "react";
 import styles from "./ResultsArea.module.css";
 import StoreCard, {
   type StoreCard as StoreCardType,
+  type RibbonVariant,
 } from "@/components/refactored/StoreCard";
 import Dropdown, {
   type DropdownOption,
 } from "@/components/refactored/Dropdown";
+import { type PillVariant } from "@/components/refactored/Pill";
+import { type Store, STORE_TAG } from "@/types";
+import { STORE_CATEGORIES } from "@/constant/storeType";
 
 const sortOptions: DropdownOption[] = [
   { label: "頂讓金：低 → 高", value: "price-asc" },
@@ -15,157 +19,70 @@ const sortOptions: DropdownOption[] = [
   { label: "最新上架", value: "newest" },
 ];
 
-const listings: StoreCardType[] = [
-  {
-    ribbon: { label: "急售", variant: "default" },
-    tags: [
-      { label: "急售", variant: "warm" },
-      { label: "餐飲", variant: "default" },
-      { label: "含設備", variant: "mus" },
-    ],
-    title: "大安溫州街 · 老字號麵店",
-    location: "台北市大安區 · 近台電大樓站 200m",
-    meta: [
-      ["坪數", "12 坪"],
-      ["月租", "4.8 萬"],
-      ["已開", "8 年"],
-      ["客群", "學生/鄰里"],
-    ],
-    price: "NT$ 65 萬",
-    rent: "含設備",
-  },
-  {
-    ribbon: { label: "含證照", variant: "sage" },
-    tags: [
-      { label: "含證照", variant: "sage" },
-      { label: "飲料", variant: "default" },
-    ],
-    title: "中山赤峰 · 手搖飲品牌店",
-    location: "台北市中山區 · 中山站 3 分鐘",
-    meta: [
-      ["坪數", "8 坪"],
-      ["月租", "3.2 萬"],
-      ["已開", "3 年"],
-      ["設備", "全新整套"],
-    ],
-    price: "NT$ 45 萬",
-    rent: "押 2 含轉約",
-  },
-  {
-    ribbon: { label: "議價", variant: "mus" },
-    tags: [
-      { label: "議價", variant: "mus" },
-      { label: "咖啡", variant: "default" },
-    ],
-    title: "大安信義 · 獨立咖啡館",
-    location: "台北市大安區 · 信義安和站",
-    meta: [
-      ["坪數", "18 坪"],
-      ["月租", "5.5 萬"],
-      ["已開", "4 年"],
-      ["客群", "上班族"],
-    ],
-    price: "NT$ 88 萬",
-    rent: "含咖啡機",
-  },
-  {
-    tags: [
-      { label: "餐飲", variant: "default" },
-      { label: "含設備", variant: "mus" },
-    ],
-    title: "松山民生社區 · 早午餐店",
-    location: "台北市松山區 · 公車站旁",
-    meta: [
-      ["坪數", "15 坪"],
-      ["月租", "4.2 萬"],
-      ["已開", "2 年"],
-      ["設備", "完整廚房"],
-    ],
-    price: "NT$ 55 萬",
-    rent: "押 2",
-  },
-  {
-    ribbon: { label: "急售", variant: "default" },
-    tags: [
-      { label: "急售", variant: "warm" },
-      { label: "餐飲", variant: "default" },
-    ],
-    title: "大同迪化街 · 文青小餐館",
-    location: "台北市大同區 · 大橋頭站",
-    meta: [
-      ["坪數", "10 坪"],
-      ["月租", "3.8 萬"],
-      ["已開", "5 年"],
-      ["客群", "觀光/在地"],
-    ],
-    price: "NT$ 38 萬",
-    rent: "含裝潢",
-  },
-  {
-    tags: [
-      { label: "餐飲", variant: "default" },
-      { label: "含證照", variant: "sage" },
-    ],
-    title: "信義永春 · 日式定食",
-    location: "台北市信義區 · 永春站 200m",
-    meta: [
-      ["坪數", "20 坪"],
-      ["月租", "6.8 萬"],
-      ["已開", "6 年"],
-      ["座位", "24 席"],
-    ],
-    price: "NT$ 95 萬",
-    rent: "含全套設備",
-  },
-  {
-    ribbon: { label: "早鳥", variant: "mus" },
-    tags: [
-      { label: "早鳥精選", variant: "mus" },
-      { label: "餐飲", variant: "default" },
-    ],
-    title: "萬華西門 · 鐵板燒",
-    location: "台北市萬華區 · 西門站 5 分",
-    meta: [
-      ["坪數", "14 坪"],
-      ["月租", "4 萬"],
-      ["已開", "3 年"],
-      ["客群", "上班族"],
-    ],
-    price: "NT$ 60 萬",
-    rent: "含吧台",
-  },
-  {
-    tags: [{ label: "餐飲", variant: "default" }],
-    title: "中正南門 · 滷味便當店",
-    location: "台北市中正區 · 公館商圈",
-    meta: [
-      ["坪數", "9 坪"],
-      ["月租", "3 萬"],
-      ["已開", "10 年"],
-      ["客群", "學生穩定"],
-    ],
-    price: "NT$ 42 萬",
-    rent: "含設備",
-  },
-  {
-    tags: [
-      { label: "餐飲", variant: "default" },
-      { label: "含設備", variant: "mus" },
-    ],
-    title: "士林天母 · 義式餐廳",
-    location: "台北市士林區 · 天母商圈",
-    meta: [
-      ["坪數", "28 坪"],
-      ["月租", "7.5 萬"],
-      ["已開", "7 年"],
-      ["座位", "40 席"],
-    ],
-    price: "NT$ 120 萬",
-    rent: "含烤箱+冷藏",
-  },
+const TAG_MAP: Record<string, { label: string; variant: PillVariant }> = {
+  [STORE_TAG.EMERGENCY]: { label: "急售", variant: "warm" },
+  [STORE_TAG.HOT]: { label: "熱門", variant: "default" },
+  [STORE_TAG.CHEAP]: { label: "划算", variant: "default" },
+  [STORE_TAG.RECOMMENDED]: { label: "精選", variant: "sage" },
+};
+
+const RIBBON_MAP: Record<string, { label: string; variant: RibbonVariant }> = {
+  [STORE_TAG.EMERGENCY]: { label: "急售", variant: "default" },
+  [STORE_TAG.RECOMMENDED]: { label: "精選", variant: "sage" },
+  [STORE_TAG.CHEAP]: { label: "划算", variant: "mus" },
+};
+
+const RIBBON_PRIORITY = [
+  STORE_TAG.EMERGENCY,
+  STORE_TAG.RECOMMENDED,
+  STORE_TAG.CHEAP,
 ];
 
-export default function ResultsArea() {
+function storeToCard(store: Store): StoreCardType {
+  const tags = store.tags ?? [];
+
+  const ribbonTag = RIBBON_PRIORITY.find((tag) => tags.includes(tag));
+  const ribbon = ribbonTag ? RIBBON_MAP[ribbonTag] : undefined;
+
+  const categoryEntry = STORE_CATEGORIES.find(
+    (cat) => cat.key === store.category,
+  );
+  const categoryLabel = categoryEntry?.label ?? store.category;
+
+  const tagPills = [
+    ...tags.map(
+      (tag) =>
+        TAG_MAP[tag] ?? { label: tag, variant: "default" as PillVariant },
+    ),
+    ...(categoryLabel
+      ? [{ label: categoryLabel, variant: "default" as PillVariant }]
+      : []),
+  ];
+
+  const location =
+    store.location ||
+    [store.city, store.district].filter(Boolean).join(" · ") ||
+    undefined;
+
+  const meta: [string, string][] = [
+    ...(categoryLabel ? [["行業", categoryLabel] as [string, string]] : []),
+    ...(store.city ? [["城市", store.city] as [string, string]] : []),
+  ];
+
+  const price = `NT$ ${Math.round(store.price / 10000)} 萬`;
+
+  return {
+    ribbon,
+    tags: tagPills,
+    title: store.storeName,
+    location,
+    meta,
+    price,
+    rent: store.description?.slice(0, 20) ?? "-",
+  };
+}
+
+export default function ResultsArea({ stores }: { stores: Store[] }) {
   const [sort, setSort] = useState("newest");
 
   return (
@@ -173,7 +90,7 @@ export default function ResultsArea() {
       <div className={styles.controlbar}>
         <div className={styles.count}>
           <span className={styles.countNum}>
-            顯示 <span className={styles.countRange}>1–9</span> / 共 412 間
+            共 <span className={styles.countRange}>{stores.length}</span> 間
           </span>
         </div>
         <Dropdown
@@ -185,8 +102,8 @@ export default function ResultsArea() {
       </div>
 
       <div className={styles.grid}>
-        {listings.map((listing) => (
-          <StoreCard key={listing.title} card={listing} />
+        {stores.map((store) => (
+          <StoreCard key={store.id} card={storeToCard(store)} />
         ))}
       </div>
 

--- a/app/new/store-list/_components/SearchBar.tsx
+++ b/app/new/store-list/_components/SearchBar.tsx
@@ -12,13 +12,12 @@ import {
   amountFilterAtom,
   categoryAtom,
 } from "@/atoms/SearchFilterAtom";
-import {
-  cityItems,
-  tagItems,
-  amountItems,
-} from "@/components/SearchFilter/DropDowns";
+import { cityItems, amountItems } from "@/components/SearchFilter/DropDowns";
 import { STORE_TAGS } from "@/constant/storeTags";
 import { STORE_CATEGORIES } from "@/constant/storeType";
+
+const toOptions = (items: { label: string; key: string }[]) =>
+  items.map((item) => ({ label: item.label, value: item.key }));
 
 export default function SearchBar() {
   const router = useRouter();
@@ -48,10 +47,7 @@ export default function SearchBar() {
     <div className={styles.searchbar}>
       <Dropdown
         label="地區"
-        options={cityItems.map((item) => ({
-          label: item.label,
-          value: item.key,
-        }))}
+        options={toOptions(cityItems)}
         value={city?.key ?? ""}
         onChange={(value) =>
           setCity(cityItems.find((item) => item.key === value))
@@ -59,21 +55,15 @@ export default function SearchBar() {
       />
       <Dropdown
         label="Tag"
-        options={STORE_TAGS.map((item) => ({
-          label: item.label,
-          value: item.key,
-        }))}
+        options={toOptions(STORE_TAGS)}
         value={tag?.key ?? ""}
         onChange={(value) =>
-          setTag(tagItems.find((item) => item.key === value))
+          setTag(STORE_TAGS.find((item) => item.key === value))
         }
       />
       <Dropdown
         label="行業"
-        options={STORE_CATEGORIES.map((item) => ({
-          label: item.label,
-          value: item.key,
-        }))}
+        options={toOptions(STORE_CATEGORIES)}
         value={category?.key ?? ""}
         onChange={(value) =>
           setCategory(STORE_CATEGORIES.find((item) => item.key === value))
@@ -81,10 +71,7 @@ export default function SearchBar() {
       />
       <Dropdown
         label="頂讓金"
-        options={amountItems.map((item) => ({
-          label: item.label,
-          value: item.key,
-        }))}
+        options={toOptions(amountItems)}
         value={amountFilter?.key ?? ""}
         onChange={(value) =>
           setAmountFilter(amountItems.find((item) => item.key === value))

--- a/app/new/store-list/_components/SearchBar.tsx
+++ b/app/new/store-list/_components/SearchBar.tsx
@@ -4,6 +4,8 @@ import styles from "./SearchBar.module.css";
 import Button from "@/components/refactored/Button";
 import Dropdown from "@/components/refactored/Dropdown";
 import { useAtom } from "jotai";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
 import {
   cityAtom,
   tagAtom,
@@ -18,23 +20,28 @@ import {
 import { STORE_TAGS } from "@/constant/storeTags";
 import { STORE_CATEGORIES } from "@/constant/storeType";
 
-export type SearchFilters = {
-  keyword: string;
-  area: string;
-  industry: string;
-  price: string;
-};
-
 export default function SearchBar() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
   const [city, setCity] = useAtom(cityAtom);
   const [tag, setTag] = useAtom(tagAtom);
   const [amountFilter, setAmountFilter] = useAtom(amountFilterAtom);
   const [category, setCategory] = useAtom(categoryAtom);
 
   const handleSearch = () => {
-    console.log("city", city);
-    console.log("tag", tag);
-    console.log("amountFilter", amountFilter);
+    const params = new URLSearchParams();
+    if (city?.key) params.set("city", city.key);
+    if (tag?.key && tag.key !== "all") params.set("tag", tag.key);
+    if (category?.key) params.set("category", category.key);
+    if (amountFilter?.value) {
+      const [min, max] = amountFilter.value;
+      if (min) params.set("amountMin", String(min));
+      if (max !== Number.POSITIVE_INFINITY)
+        params.set("amountMax", String(max));
+    }
+    startTransition(() => {
+      router.push(`/new/store-list?${params.toString()}`);
+    });
   };
 
   return (
@@ -83,7 +90,9 @@ export default function SearchBar() {
           setAmountFilter(amountItems.find((item) => item.key === value))
         }
       />
-      <Button onClick={handleSearch}>🔍 搜尋</Button>
+      <Button onClick={handleSearch} disabled={isPending}>
+        {isPending ? "搜尋中…" : "🔍 搜尋"}
+      </Button>
     </div>
   );
 }

--- a/app/new/store-list/page.tsx
+++ b/app/new/store-list/page.tsx
@@ -7,6 +7,7 @@ import Breadcrumbs from "./_components/Breadcrumbs";
 import SearchBar from "./_components/SearchBar";
 import ActiveFilters from "./_components/ActiveFilters";
 import ResultsArea from "./_components/ResultsArea";
+import { getStores } from "@/firebase/serverUtils";
 
 export const metadata: Metadata = {
   title: "頂讓.tw — 我要找店",
@@ -14,16 +15,25 @@ export const metadata: Metadata = {
     "瀏覽全台頂讓店面。依地區、行業、頂讓金快速篩選，直接聯絡賣家，沒有中間人。",
 };
 
-export default function StoreListPage() {
+interface PageProps {
+  searchParams: URLSearchParams;
+}
+
+export default async function StoreListPage({ searchParams }: PageProps) {
+  const storeSearchParams = new URLSearchParams(searchParams);
+  const searchObj = Object.fromEntries(storeSearchParams);
+
+  const stores = await getStores(searchObj);
+
   return (
     <>
       <LaunchBanner />
       <SiteNav activeLink="我要找店" />
       <main className={styles.main}>
-        <Breadcrumbs />
+        <Breadcrumbs count={stores.length} />
         <SearchBar />
         <ActiveFilters />
-        <ResultsArea />
+        <ResultsArea stores={stores} />
       </main>
       <SiteFooter />
     </>

--- a/atoms/SearchFilterAtom.ts
+++ b/atoms/SearchFilterAtom.ts
@@ -51,5 +51,5 @@ export const filtersAtom = atom(
 );
 
 // * drawer ui
-type FilterKey = "city" | "tag" | "amountFilter" | "category";
+export type FilterKey = "city" | "tag" | "amountFilter" | "category";
 export const activeDrawerCardAtom = atom<FilterKey | undefined>("city");

--- a/components/refactored/Button.module.css
+++ b/components/refactored/Button.module.css
@@ -28,6 +28,12 @@
   transform: translate(-1px, -1px);
   box-shadow: 3px 3px 0 var(--ink);
 }
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: 2px 2px 0 var(--ink);
+}
 
 .md {
   padding: 8px 16px;

--- a/components/refactored/Button.tsx
+++ b/components/refactored/Button.tsx
@@ -8,12 +8,14 @@ export default function Button({
   size = "md",
   children,
   className,
+  disabled,
   onClick,
 }: {
   variant?: ButtonVariant;
   size?: "md" | "sm";
   children: React.ReactNode;
   className?: string;
+  disabled?: boolean;
   onClick?: () => void;
 }) {
   const variantCls = variant === "default" ? "" : styles[variant];
@@ -21,6 +23,7 @@ export default function Button({
   return (
     <button
       className={cn(styles.btn, variantCls, sizeCls, className)}
+      disabled={disabled}
       onClick={onClick}
     >
       {children}

--- a/constant/storeDisplay.ts
+++ b/constant/storeDisplay.ts
@@ -1,0 +1,28 @@
+import { type PillVariant } from "@/components/refactored/Pill";
+import { type RibbonVariant } from "@/components/refactored/StoreCard";
+import { STORE_TAG } from "@/types";
+
+export const TAG_DISPLAY: Record<
+  string,
+  { label: string; variant: PillVariant }
+> = {
+  [STORE_TAG.EMERGENCY]: { label: "急售", variant: "warm" },
+  [STORE_TAG.HOT]: { label: "熱門", variant: "default" },
+  [STORE_TAG.CHEAP]: { label: "划算", variant: "default" },
+  [STORE_TAG.RECOMMENDED]: { label: "精選", variant: "sage" },
+};
+
+export const RIBBON_DISPLAY: Record<
+  string,
+  { label: string; variant: RibbonVariant }
+> = {
+  [STORE_TAG.EMERGENCY]: { label: "急售", variant: "default" },
+  [STORE_TAG.RECOMMENDED]: { label: "精選", variant: "sage" },
+  [STORE_TAG.CHEAP]: { label: "划算", variant: "mus" },
+};
+
+export const RIBBON_PRIORITY = [
+  STORE_TAG.EMERGENCY,
+  STORE_TAG.RECOMMENDED,
+  STORE_TAG.CHEAP,
+];


### PR DESCRIPTION
Closes #14

## Summary

- `page.tsx` — converted to async server component; reads `searchParams`, calls `getStores()`, passes `Store[]` and count as props
- `ResultsArea.tsx` — accepts `stores: Store[]`, maps via `storeToCard()`, client-side sort by price / newest
- `SearchBar.tsx` — `handleSearch` pushes URL search params from Jotai atoms; `useTransition` shows loading state on button
- `Breadcrumbs.tsx` — count is now dynamic from real results
- `constant/storeDisplay.ts` — new shared file for `TAG_DISPLAY`, `RIBBON_DISPLAY`, `RIBBON_PRIORITY`
- `atoms/SearchFilterAtom.ts` — exports `FilterKey` type
- `ActiveFilters.tsx` — `handleRemove` typed with `FilterKey`

## Test plan

- [x] Navigate to `/new/store-list` — real store cards render (not hardcoded)
- [x] Select a city filter and click 搜尋 — URL updates, results filter
- [x] Clear filters — navigate to `/new/store-list` — all stores show
- [x] Count in Breadcrumbs matches result count
- [x] Sort dropdown reorders cards (price asc/desc, newest)
- [x] Search button shows 搜尋中… and is disabled while loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)