### PR TITLE
feat(store-detail): implement redesigned 物件詳情 page under /new route

### DIFF
--- a/app/new/store-list/_components/ResultsArea.module.css
+++ b/app/new/store-list/_components/ResultsArea.module.css
@@ -39,6 +39,12 @@
   gap: 14px;
 }
 
+.cardLink {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
 .saveCta {
   margin-top: 24px;
   border: 1.5px dashed var(--ink);

--- a/app/new/store-list/_components/ResultsArea.tsx
+++ b/app/new/store-list/_components/ResultsArea.tsx
@@ -96,7 +96,13 @@ export default function ResultsArea({ stores }: { stores: Store[] }) {
 
       <div className={styles.grid}>
         {sortedStores.map((store) => (
-          <StoreCard key={store.id} card={storeToCard(store)} />
+          <a
+            key={store.id}
+            href={`/new/store/${store.id}`}
+            className={styles.cardLink}
+          >
+            <StoreCard card={storeToCard(store)} />
+          </a>
         ))}
       </div>
 

--- a/app/new/store/[storeId]/_components/StoreBreadcrumb.module.css
+++ b/app/new/store/[storeId]/_components/StoreBreadcrumb.module.css
@@ -1,0 +1,55 @@
+.crumbs {
+  padding: 12px 28px;
+  border-bottom: 1.5px solid var(--ink);
+  background: var(--paper-2);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.trail {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-2);
+  letter-spacing: 0.05em;
+
+  & a {
+    color: var(--ink-2);
+    text-decoration: none;
+  }
+
+  & a:hover {
+    color: var(--accent);
+  }
+
+  & b {
+    color: var(--ink);
+  }
+}
+
+.actions {
+  font-family: var(--hand);
+  font-size: 12px;
+  color: var(--ink-2);
+  display: flex;
+  gap: 14px;
+  align-items: center;
+
+  & span {
+    cursor: pointer;
+  }
+
+  & span:hover {
+    color: var(--accent);
+  }
+}
+
+.report {
+  color: var(--muted);
+
+  &:hover {
+    color: var(--muted) !important;
+  }
+}

--- a/app/new/store/[storeId]/_components/StoreBreadcrumb.module.css
+++ b/app/new/store/[storeId]/_components/StoreBreadcrumb.module.css
@@ -45,11 +45,3 @@
     color: var(--accent);
   }
 }
-
-.report {
-  color: var(--muted);
-
-  &:hover {
-    color: var(--muted) !important;
-  }
-}

--- a/app/new/store/[storeId]/_components/StoreBreadcrumb.tsx
+++ b/app/new/store/[storeId]/_components/StoreBreadcrumb.tsx
@@ -14,10 +14,7 @@ export default function StoreBreadcrumb({ store }: { store: Store }) {
         <b>{storeName}</b>
       </div>
       <div className={styles.actions}>
-        <span>♡ 收藏物件</span>
         <span>📤 分享</span>
-        <span>🖨 列印</span>
-        <span className={styles.report}>⋯ 檢舉</span>
       </div>
     </div>
   );

--- a/app/new/store/[storeId]/_components/StoreBreadcrumb.tsx
+++ b/app/new/store/[storeId]/_components/StoreBreadcrumb.tsx
@@ -1,0 +1,24 @@
+import type { Store } from "@/types";
+import styles from "./StoreBreadcrumb.module.css";
+
+export default function StoreBreadcrumb({ store }: { store: Store }) {
+  const { storeName } = store;
+
+  return (
+    <div className={styles.crumbs}>
+      <div className={styles.trail}>
+        <a href="/new">首頁</a>
+        {" / "}
+        <a href="/new/store-list">我要找店</a>
+        {" / "}
+        <b>{storeName}</b>
+      </div>
+      <div className={styles.actions}>
+        <span>♡ 收藏物件</span>
+        <span>📤 分享</span>
+        <span>🖨 列印</span>
+        <span className={styles.report}>⋯ 檢舉</span>
+      </div>
+    </div>
+  );
+}

--- a/app/new/store/[storeId]/_components/StoreDescription.module.css
+++ b/app/new/store/[storeId]/_components/StoreDescription.module.css
@@ -1,0 +1,33 @@
+.section {
+  margin-bottom: 32px;
+}
+
+.heading {
+  font-family: var(--display);
+  font-size: 32px;
+  font-weight: 700;
+  margin: 0 0 12px;
+  line-height: 1;
+  border-bottom: 1.5px dashed var(--ink);
+  padding-bottom: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+
+  & small {
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--ink-2);
+    font-weight: 400;
+    letter-spacing: 0.1em;
+  }
+}
+
+.body {
+  font-family: var(--hand);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--ink);
+  margin: 8px 0;
+  white-space: pre-line;
+}

--- a/app/new/store/[storeId]/_components/StoreDescription.tsx
+++ b/app/new/store/[storeId]/_components/StoreDescription.tsx
@@ -1,0 +1,16 @@
+import styles from "./StoreDescription.module.css";
+
+export default function StoreDescription({
+  description,
+}: {
+  description: string;
+}) {
+  return (
+    <div className={styles.section}>
+      <h3 className={styles.heading}>
+        物件描述 <small>SELLER STORY</small>
+      </h3>
+      <p className={styles.body}>{description}</p>
+    </div>
+  );
+}

--- a/app/new/store/[storeId]/_components/StoreGallery.module.css
+++ b/app/new/store/[storeId]/_components/StoreGallery.module.css
@@ -1,0 +1,104 @@
+.wrapper {
+  padding: 18px 28px;
+  background: var(--paper-2);
+  border-bottom: 1.5px solid var(--ink);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 2.4fr 1fr 1fr;
+  grid-template-rows: 200px 200px;
+  gap: 6px;
+}
+
+.hero {
+  grid-row: 1 / 3;
+  position: relative;
+  border: 1.5px solid var(--ink);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.thumb {
+  position: relative;
+  border: 1.5px solid var(--ink);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.img {
+  object-fit: cover;
+}
+
+.placeholder {
+  width: 100%;
+  height: 100%;
+  background: repeating-linear-gradient(
+    45deg,
+    #d8cfb6,
+    #d8cfb6 8px,
+    #cfc4a8 8px,
+    #cfc4a8 16px
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  & span {
+    background: var(--paper);
+    border: 1.5px solid var(--ink);
+    border-radius: 3px;
+    padding: 3px 10px;
+    font-family: var(--hand);
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--ink);
+  }
+}
+
+.ribbon {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: var(--accent);
+  color: #fff;
+  padding: 3px 9px;
+  border: 1.5px solid var(--ink);
+  border-radius: 3px;
+  font-family: var(--hand);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  z-index: 1;
+}
+
+.photoCount {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  background: var(--paper);
+  padding: 5px 12px;
+  border: 1.5px solid var(--ink);
+  border-radius: 99px;
+  font-family: var(--hand);
+  font-size: 12px;
+  font-weight: 700;
+  box-shadow: 2px 2px 0 var(--ink);
+  cursor: pointer;
+}
+
+.heart {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 1.5px solid var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  cursor: pointer;
+}

--- a/app/new/store/[storeId]/_components/StoreGallery.tsx
+++ b/app/new/store/[storeId]/_components/StoreGallery.tsx
@@ -1,0 +1,61 @@
+import Image from "next/image";
+import type { StoreTag } from "@/types";
+import { STORE_TAG } from "@/types/StoreTags";
+import styles from "./StoreGallery.module.css";
+
+interface StoreGalleryProps {
+  images: string[];
+  tags?: StoreTag[];
+}
+
+function Placeholder({ label }: { label: string }) {
+  return (
+    <div className={styles.placeholder}>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export default function StoreGallery({ images, tags }: StoreGalleryProps) {
+  const isUrgent = tags?.includes(STORE_TAG.EMERGENCY);
+  const slots = Array.from({ length: 5 }, (_, index) => images[index] ?? null);
+  const totalImages = images.length;
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.grid}>
+        {/* Hero — spans both rows */}
+        <div className={styles.hero}>
+          {slots[0] ? (
+            <Image src={slots[0]} fill alt="店面主圖" className={styles.img} />
+          ) : (
+            <Placeholder label="店面外觀" />
+          )}
+          {isUrgent && <span className={styles.ribbon}>急售</span>}
+          {totalImages > 0 && (
+            <span className={styles.photoCount}>
+              📷 查看全部 {totalImages} 張
+            </span>
+          )}
+          <span className={styles.heart}>♡</span>
+        </div>
+
+        {/* 4 thumbnails */}
+        {[
+          { src: slots[1], label: "內裝" },
+          { src: slots[2], label: "廚房" },
+          { src: slots[3], label: "設備" },
+          { src: slots[4], label: "其他" },
+        ].map(({ src, label }) => (
+          <div key={label} className={styles.thumb}>
+            {src ? (
+              <Image src={src} fill alt={label} className={styles.img} />
+            ) : (
+              <Placeholder label={label} />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/new/store/[storeId]/_components/StorePriceCard.module.css
+++ b/app/new/store/[storeId]/_components/StorePriceCard.module.css
@@ -1,0 +1,95 @@
+.card {
+  position: sticky;
+  top: 14px;
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  border-radius: 6px;
+  box-shadow: 4px 4px 0 var(--ink);
+  padding: 20px 18px;
+}
+
+.label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-2);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  display: block;
+}
+
+.price {
+  font-family: var(--display);
+  font-size: 64px;
+  font-weight: 700;
+  line-height: 0.95;
+  color: var(--ink);
+  margin: 4px 0 0;
+
+  & em {
+    font-style: normal;
+    font-family: var(--hand);
+    font-size: 18px;
+    color: var(--ink-2);
+    font-weight: 400;
+    margin-left: 4px;
+  }
+}
+
+.cta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.ctaLink {
+  display: block;
+  text-decoration: none;
+}
+
+.btn {
+  width: 100%;
+  font-size: 16px;
+  padding: 11px 20px;
+}
+
+.visit {
+  background: var(--paper-2) !important;
+}
+
+.trust {
+  background: var(--accent-3);
+  border: 1.5px solid var(--ink);
+  border-radius: 4px;
+  padding: 10px 12px;
+  margin-top: 14px;
+  font-family: var(--hand);
+  font-size: 12px;
+  color: var(--ink);
+  line-height: 1.5;
+
+  & b {
+    display: block;
+    font-family: var(--display);
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1;
+    margin-bottom: 4px;
+  }
+}
+
+.report {
+  text-align: center;
+  font-family: var(--hand);
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 18px;
+  border-top: 1px dashed var(--paper-3);
+  padding-top: 10px;
+
+  & a {
+    color: var(--muted);
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}

--- a/app/new/store/[storeId]/_components/StorePriceCard.module.css
+++ b/app/new/store/[storeId]/_components/StorePriceCard.module.css
@@ -1,6 +1,4 @@
 .card {
-  position: sticky;
-  top: 14px;
   border: 2px solid var(--ink);
   background: var(--paper);
   border-radius: 6px;

--- a/app/new/store/[storeId]/_components/StorePriceCard.tsx
+++ b/app/new/store/[storeId]/_components/StorePriceCard.tsx
@@ -1,0 +1,52 @@
+import Button from "@/components/refactored/Button";
+import type { Store } from "@/types";
+import styles from "./StorePriceCard.module.css";
+
+export default function StorePriceCard({ store }: { store: Store }) {
+  const { price, userInfo } = store;
+  const priceInWan = (price / 10000).toFixed(0);
+
+  return (
+    <div className={styles.card}>
+      <span className={styles.label}>頂讓金 ASKING</span>
+      <div className={styles.price}>
+        NT$ {priceInWan}
+        <em>萬</em>
+      </div>
+
+      <div className={styles.cta}>
+        <a href={`tel:${userInfo?.phone}`} className={styles.ctaLink}>
+          <Button className={styles.btn}>📞 撥打賣家電話</Button>
+        </a>
+        {userInfo?.lineId && (
+          <a
+            href={`https://line.me/ti/p/~${userInfo.lineId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.ctaLink}
+          >
+            <Button variant="sage" className={styles.btn}>
+              💬 加 LINE 聯繫
+            </Button>
+          </a>
+        )}
+        <Button variant="ghost" className={styles.btn}>
+          ✉️ 站內留言
+        </Button>
+        <Button variant="ghost" className={`${styles.btn} ${styles.visit}`}>
+          📅 預約現場看店
+        </Button>
+      </div>
+
+      <div className={styles.trust}>
+        <b>必售！安心提示</b>
+        本物件由賣家直接刊登，Bezold 不收取仲介費，洽談 / 議價 /
+        簽約皆為買賣雙方直接進行。建議現場看過再決定。
+      </div>
+
+      <div className={styles.report}>
+        資訊有疑慮？ <a>檢舉此物件</a> · <a>聯絡客服</a>
+      </div>
+    </div>
+  );
+}

--- a/app/new/store/[storeId]/_components/StorePriceCard.tsx
+++ b/app/new/store/[storeId]/_components/StorePriceCard.tsx
@@ -15,9 +15,11 @@ export default function StorePriceCard({ store }: { store: Store }) {
       </div>
 
       <div className={styles.cta}>
-        <a href={`tel:${userInfo?.phone}`} className={styles.ctaLink}>
-          <Button className={styles.btn}>📞 撥打賣家電話</Button>
-        </a>
+        {userInfo?.phone && (
+          <a href={`tel:${userInfo.phone}`} className={styles.ctaLink}>
+            <Button className={styles.btn}>📞 撥打賣家電話</Button>
+          </a>
+        )}
         {userInfo?.lineId && (
           <a
             href={`https://line.me/ti/p/~${userInfo.lineId}`}

--- a/app/new/store/[storeId]/_components/StoreSellerInfo.module.css
+++ b/app/new/store/[storeId]/_components/StoreSellerInfo.module.css
@@ -1,0 +1,92 @@
+.seller {
+  border: 1.5px solid var(--ink);
+  background: #fff;
+  border-radius: 6px;
+  padding: 14px 16px;
+  margin-top: 14px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 1.5px solid var(--ink);
+  background: var(--accent-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--display);
+  font-size: 22px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.name {
+  font-family: var(--display);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+
+  & small {
+    display: block;
+    font-family: var(--hand);
+    font-size: 11px;
+    color: var(--ink-2);
+    margin-top: 3px;
+    font-weight: 400;
+  }
+}
+
+.badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--hand);
+  font-size: 11px;
+  border: 1.5px solid var(--ink);
+  background: var(--paper-2);
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-weight: 700;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-2);
+  flex-shrink: 0;
+}
+
+.warm .dot {
+  background: var(--accent);
+}
+
+.meta {
+  font-family: var(--hand);
+  font-size: 12px;
+  color: var(--ink-2);
+  line-height: 1.6;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--paper-3);
+
+  & b {
+    color: var(--ink);
+    font-weight: 700;
+  }
+}

--- a/app/new/store/[storeId]/_components/StoreSellerInfo.tsx
+++ b/app/new/store/[storeId]/_components/StoreSellerInfo.tsx
@@ -1,0 +1,45 @@
+import type { Store } from "@/types";
+import { STORE_TAG } from "@/types/StoreTags";
+import styles from "./StoreSellerInfo.module.css";
+
+export default function StoreSellerInfo({ store }: { store: Store }) {
+  const { userInfo, tags } = store;
+
+  if (!userInfo) return null;
+
+  const { userName, phone } = userInfo;
+  const isUrgent = tags?.includes(STORE_TAG.EMERGENCY);
+
+  return (
+    <div className={styles.seller}>
+      <div className={styles.row}>
+        <div className={styles.avatar}>{userName.charAt(0)}</div>
+        <div>
+          <div className={styles.name}>
+            {userName}
+            <small>屋主直接刊登</small>
+          </div>
+          <div className={styles.badges}>
+            <span className={styles.badge}>
+              <span className={styles.dot} />
+              身份已驗證
+            </span>
+            {isUrgent && (
+              <span className={`${styles.badge} ${styles.warm}`}>
+                <span className={styles.dot} />
+                急售標記
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className={styles.meta}>
+        聯絡電話 <b>{phone}</b>
+        <br />
+        回覆速度 <b>平均 2 小時內</b>
+        <br />
+        活躍時間 <b>09:00 ~ 21:00</b>
+      </div>
+    </div>
+  );
+}

--- a/app/new/store/[storeId]/_components/StoreTitleRow.module.css
+++ b/app/new/store/[storeId]/_components/StoreTitleRow.module.css
@@ -1,0 +1,52 @@
+.row {
+  padding: 24px 28px 18px;
+  border-bottom: 1.5px solid var(--ink);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+}
+
+.tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.name {
+  font-family: var(--display);
+  font-size: 44px;
+  margin: 0;
+  font-weight: 700;
+  line-height: 1;
+
+  & em {
+    font-style: normal;
+    color: var(--accent);
+  }
+}
+
+.loc {
+  font-family: var(--hand);
+  font-size: 15px;
+  color: var(--ink-2);
+  margin-top: 8px;
+}
+
+.meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  text-align: right;
+  line-height: 1.8;
+  white-space: nowrap;
+
+  & b {
+    color: var(--ink);
+    font-weight: 600;
+    display: block;
+    font-size: 14px;
+    margin-bottom: 2px;
+  }
+}

--- a/app/new/store/[storeId]/_components/StoreTitleRow.tsx
+++ b/app/new/store/[storeId]/_components/StoreTitleRow.tsx
@@ -1,0 +1,58 @@
+import dayjs from "dayjs";
+import Pill from "@/components/refactored/Pill";
+import type { Store } from "@/types";
+import { STORE_TAG } from "@/types/StoreTags";
+import styles from "./StoreTitleRow.module.css";
+
+const TAG_VARIANT = {
+  [STORE_TAG.EMERGENCY]: "warm",
+  [STORE_TAG.HOT]: "warm",
+  [STORE_TAG.RECOMMENDED]: "sage",
+  [STORE_TAG.CHEAP]: "mus",
+} as const;
+
+export default function StoreTitleRow({ store }: { store: Store }) {
+  const {
+    id,
+    storeName,
+    city,
+    district,
+    location,
+    tags,
+    category,
+    createTime,
+    updateTime,
+  } = store;
+
+  return (
+    <div className={styles.row}>
+      <div>
+        <div className={styles.tags}>
+          {tags?.map((tag) => (
+            <Pill key={tag} variant={TAG_VARIANT[tag]}>
+              {tag === STORE_TAG.EMERGENCY && "急售"}
+              {tag === STORE_TAG.HOT && "熱門"}
+              {tag === STORE_TAG.RECOMMENDED && "推薦"}
+              {tag === STORE_TAG.CHEAP && "優惠"}
+            </Pill>
+          ))}
+          {category && <Pill>{category}</Pill>}
+        </div>
+        <h2 className={styles.name}>
+          {city && <>{city} · </>}
+          <em>{storeName}</em>
+        </h2>
+        <div className={styles.loc}>
+          📍 {city}
+          {district} · {location}
+        </div>
+      </div>
+      <div className={styles.meta}>
+        <b>#{id.slice(-5)}</b>
+        上架 · {dayjs(createTime).format("YYYY/MM/DD")}
+        <br />
+        更新 · {dayjs(updateTime).format("YYYY/MM/DD")}
+      </div>
+    </div>
+  );
+}

--- a/app/new/store/[storeId]/error.tsx
+++ b/app/new/store/[storeId]/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Button from "@/components/refactored/Button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    console.log(error);
+  }, [error]);
+
+  return (
+    <div className="w-[480px] mt-[64px] mx-auto text-center pt-[150px]">
+      <h2>找不到這個物件</h2>
+      <div className="flex justify-center mt-[16px] gap-x-[16px]">
+        <Button variant="ghost" onClick={reset}>
+          再試一次
+        </Button>
+        <Button onClick={() => router.push("/new/store-list")}>
+          回到找店列表
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/new/store/[storeId]/page.module.css
+++ b/app/new/store/[storeId]/page.module.css
@@ -15,6 +15,9 @@
 .side {
   padding: 28px;
   background: var(--paper-2);
+  position: sticky;
+  top: 0;
+  align-self: start;
 }
 
 .disclaimer {

--- a/app/new/store/[storeId]/page.module.css
+++ b/app/new/store/[storeId]/page.module.css
@@ -2,22 +2,8 @@
   flex: 1;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: 1.6fr 1fr;
-}
-
 .mainCol {
   padding: 28px;
-  border-right: 1.5px dashed var(--ink);
-}
-
-.side {
-  padding: 28px;
-  background: var(--paper-2);
-  position: sticky;
-  top: 0;
-  align-self: start;
 }
 
 .disclaimer {

--- a/app/new/store/[storeId]/page.module.css
+++ b/app/new/store/[storeId]/page.module.css
@@ -1,0 +1,28 @@
+.main {
+  flex: 1;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+}
+
+.mainCol {
+  padding: 28px;
+  border-right: 1.5px dashed var(--ink);
+}
+
+.side {
+  padding: 28px;
+  background: var(--paper-2);
+}
+
+.disclaimer {
+  padding: 18px 28px;
+  font-family: var(--hand);
+  font-size: 12px;
+  color: var(--ink-2);
+  background: var(--paper-2);
+  border-top: 1.5px solid var(--ink);
+  line-height: 1.6;
+}

--- a/app/new/store/[storeId]/page.tsx
+++ b/app/new/store/[storeId]/page.tsx
@@ -5,6 +5,7 @@ import SiteNav from "@/app/new/_components/SiteNav";
 import SiteFooter from "@/app/new/_components/SiteFooter";
 import StoreBreadcrumb from "./_components/StoreBreadcrumb";
 import StoreGallery from "./_components/StoreGallery";
+import StoreTitleRow from "./_components/StoreTitleRow";
 import styles from "./page.module.css";
 
 interface StorePageProps {
@@ -56,6 +57,7 @@ export default async function StoreDetailPage({ params }: StorePageProps) {
       <main className={styles.main}>
         <StoreBreadcrumb store={store} />
         <StoreGallery images={store.images} tags={store.tags} />
+        <StoreTitleRow store={store} />
         <div className={styles.grid}>
           <div className={styles.mainCol}>{/* components coming soon */}</div>
           <div className={styles.side}>{/* components coming soon */}</div>

--- a/app/new/store/[storeId]/page.tsx
+++ b/app/new/store/[storeId]/page.tsx
@@ -8,6 +8,7 @@ import StoreGallery from "./_components/StoreGallery";
 import StoreTitleRow from "./_components/StoreTitleRow";
 import StoreDescription from "./_components/StoreDescription";
 import StorePriceCard from "./_components/StorePriceCard";
+import StoreSellerInfo from "./_components/StoreSellerInfo";
 import styles from "./page.module.css";
 
 interface StorePageProps {
@@ -66,6 +67,7 @@ export default async function StoreDetailPage({ params }: StorePageProps) {
           </div>
           <div className={styles.side}>
             <StorePriceCard store={store} />
+            <StoreSellerInfo store={store} />
           </div>
         </div>
       </main>

--- a/app/new/store/[storeId]/page.tsx
+++ b/app/new/store/[storeId]/page.tsx
@@ -6,6 +6,7 @@ import SiteFooter from "@/app/new/_components/SiteFooter";
 import StoreBreadcrumb from "./_components/StoreBreadcrumb";
 import StoreGallery from "./_components/StoreGallery";
 import StoreTitleRow from "./_components/StoreTitleRow";
+import StoreDescription from "./_components/StoreDescription";
 import styles from "./page.module.css";
 
 interface StorePageProps {
@@ -59,7 +60,9 @@ export default async function StoreDetailPage({ params }: StorePageProps) {
         <StoreGallery images={store.images} tags={store.tags} />
         <StoreTitleRow store={store} />
         <div className={styles.grid}>
-          <div className={styles.mainCol}>{/* components coming soon */}</div>
+          <div className={styles.mainCol}>
+            <StoreDescription description={store.description} />
+          </div>
           <div className={styles.side}>{/* components coming soon */}</div>
         </div>
       </main>

--- a/app/new/store/[storeId]/page.tsx
+++ b/app/new/store/[storeId]/page.tsx
@@ -7,6 +7,7 @@ import StoreBreadcrumb from "./_components/StoreBreadcrumb";
 import StoreGallery from "./_components/StoreGallery";
 import StoreTitleRow from "./_components/StoreTitleRow";
 import StoreDescription from "./_components/StoreDescription";
+import StorePriceCard from "./_components/StorePriceCard";
 import styles from "./page.module.css";
 
 interface StorePageProps {
@@ -63,7 +64,9 @@ export default async function StoreDetailPage({ params }: StorePageProps) {
           <div className={styles.mainCol}>
             <StoreDescription description={store.description} />
           </div>
-          <div className={styles.side}>{/* components coming soon */}</div>
+          <div className={styles.side}>
+            <StorePriceCard store={store} />
+          </div>
         </div>
       </main>
       <SiteFooter />

--- a/app/new/store/[storeId]/page.tsx
+++ b/app/new/store/[storeId]/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import { getStoreById } from "@/firebase/serverUtils";
+import LaunchBanner from "@/app/new/_components/LaunchBanner";
+import SiteNav from "@/app/new/_components/SiteNav";
+import SiteFooter from "@/app/new/_components/SiteFooter";
+import StoreBreadcrumb from "./_components/StoreBreadcrumb";
+import StoreGallery from "./_components/StoreGallery";
+import styles from "./page.module.css";
+
+interface StorePageProps {
+  params: { storeId: string };
+}
+
+export async function generateMetadata(
+  { params }: StorePageProps,
+  parent: ResolvingMetadata,
+): Promise<Metadata> {
+  const { storeId } = await params;
+  const store = await getStoreById(storeId);
+
+  if (!store) {
+    return {
+      title: "頂讓.tw — 找不到物件",
+      openGraph: {
+        title: "頂讓.tw — 找不到物件",
+        description: "此物件不存在或已下架",
+        url: `${process.env.NEXT_PUBLIC_APP_URL}/new/store/${storeId}`,
+        images: ["/assets/bezold.png"],
+      },
+    };
+  }
+
+  return {
+    title: `頂讓.tw — ${store.storeName}`,
+    openGraph: {
+      title: `頂讓.tw — ${store.storeName}`,
+      description: store.description,
+      url: `${process.env.NEXT_PUBLIC_APP_URL}/new/store/${storeId}`,
+      images: store.images.length ? store.images : ["/assets/bezold.png"],
+    },
+  };
+}
+
+export default async function StoreDetailPage({ params }: StorePageProps) {
+  const { storeId } = await params;
+  const store = await getStoreById(storeId);
+
+  if (!store) {
+    throw new Error("Store not found");
+  }
+
+  return (
+    <>
+      <LaunchBanner />
+      <SiteNav activeLink="我要找店" />
+      <main className={styles.main}>
+        <StoreBreadcrumb store={store} />
+        <StoreGallery images={store.images} tags={store.tags} />
+        <div className={styles.grid}>
+          <div className={styles.mainCol}>{/* components coming soon */}</div>
+          <div className={styles.side}>{/* components coming soon */}</div>
+        </div>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/app/new/store/[storeId]/page.tsx
+++ b/app/new/store/[storeId]/page.tsx
@@ -61,14 +61,10 @@ export default async function StoreDetailPage({ params }: StorePageProps) {
         <StoreBreadcrumb store={store} />
         <StoreGallery images={store.images} tags={store.tags} />
         <StoreTitleRow store={store} />
-        <div className={styles.grid}>
-          <div className={styles.mainCol}>
-            <StoreDescription description={store.description} />
-          </div>
-          <div className={styles.side}>
-            <StorePriceCard store={store} />
-            <StoreSellerInfo store={store} />
-          </div>
+        <div className={styles.mainCol}>
+          <StoreDescription description={store.description} />
+          <StorePriceCard store={store} />
+          <StoreSellerInfo store={store} />
         </div>
       </main>
       <SiteFooter />

--- a/components/refactored/Button.module.css
+++ b/components/refactored/Button.module.css
@@ -23,6 +23,10 @@
     color: var(--ink);
     box-shadow: none;
   }
+  &.sage {
+    background: var(--accent-2);
+    color: #fff;
+  }
 }
 .btn:hover {
   transform: translate(-1px, -1px);

--- a/components/refactored/Button.tsx
+++ b/components/refactored/Button.tsx
@@ -1,7 +1,7 @@
 import styles from "./Button.module.css";
 import { cn } from "@/lib/utils";
 
-export type ButtonVariant = "default" | "mus" | "ghost";
+export type ButtonVariant = "default" | "mus" | "ghost" | "sage";
 
 export default function Button({
   variant = "default",


### PR DESCRIPTION
## Summary

Implements the redesigned store detail page at `/new/store/[storeId]` based on the design spec from `bezold-rebrand/project/頂讓 物件詳情.html`. The page lives under the `/new` route tree alongside the existing homepage and store-list, using the same CSS variable / CSS Modules design system.

Also wires up the store-list cards so clicking a store navigates to the new detail page.

## What changed

- **`components/refactored/Button`** — added `sage` (green) variant for the LINE CTA
- **`app/new/store/[storeId]/`** — new route with:
  - `StoreBreadcrumb` — trail (首頁 / 我要找店 / storeName) + 📤 分享 action
  - `StoreGallery` — CSS grid (2.4fr 1fr 1fr, two 200px rows); hero + 4 thumbnails; hatched placeholder for missing images; EMERGENCY ribbon + heart overlay
  - `StoreTitleRow` — tag pills mapped to Pill variants, store name in `--display` 44px, location line, listing meta in `--mono`
  - `StoreDescription` — seller story section with dashed heading
  - `StorePriceCard` — price in `--display` 64px; phone `tel:` link (only shown when `userInfo.phone` exists); conditional LINE button; trust callout
  - `StoreSellerInfo` — avatar circle, name, verified badge, urgent badge, phone + meta
  - `error.tsx` — error boundary using refactored Button
  - **Single-column layout** — description, price card, and seller info stack vertically (2-column grid removed as content is limited for MVP)
- **`app/new/store-list/_components/ResultsArea`** — wraps each `StoreCard` in `<a href="/new/store/[id]">` to connect the list → detail flow

## Skipped for MVP (per spec)

設備清單, 近 6 個月營收, 地段/周邊, 適合接手者, 類似物件, Facts grid (no schema fields yet), Why selling quote (no schema field yet)

## Test plan

- [x] Navigate to `/new/store-list` → click a store card → lands on `/new/store/[id]`
- [x] Gallery: stores with images show photos; stores without show hatched placeholder
- [x] Tags map to correct Pill variants (EMERGENCY→warm, RECOMMENDED→sage, CHEAP→mus)
- [x] Phone button only appears when `userInfo.phone` is set; LINE button only when `userInfo.lineId` is set
- [x] `npm run lint` passes
- [x] `npm run build` passes

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)