### PR TITLE
feat: 限時免費刊登 — auth-gated seller form, image upload, store status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,14 @@ No test runner is configured.
 
 ### Route groups
 
-| Group                     | Purpose                                             |
-| ------------------------- | --------------------------------------------------- |
-| `app/(LayoutWithBasic)/`  | Main marketplace pages (home, browse, store detail) |
-| `app/(LayoutWithNav)/`    | Pages with persistent nav bar                       |
-| `app/(LayoutWithoutNav)/` | Minimal layout (auth, onboarding)                   |
-| `app/admin/`              | Admin dashboard (Firebase custom-claims gating)     |
-| `app/new/`                | Store creation and editing flows                    |
-| `app/api/`                | Route handlers (admin auth, stores)                 |
+| Group                     | Purpose                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| `app/(LayoutWithBasic)/`  | Main marketplace pages (home, browse, store detail)                                   |
+| `app/(LayoutWithNav)/`    | Pages with persistent nav bar                                                         |
+| `app/(LayoutWithoutNav)/` | Minimal layout (auth, onboarding)                                                     |
+| `app/admin/`              | Admin dashboard (Firebase custom-claims gating)                                       |
+| `app/new/`                | Redesigned public-facing site — auth, store browse, store detail, seller listing form |
+| `app/api/`                | Route handlers (admin auth, stores)                                                   |
 
 ### Key directories
 
@@ -37,13 +37,17 @@ No test runner is configured.
 - `firebase/client.ts` — exports `db`, `storage`, `auth` (browser SDK).
 - `firebase/server.ts` — exports `db`, `bucket`, `adminAuth` (Admin SDK, server-only).
 - `hooks/` — `useAdminAuth` (Firebase auth + admin token), `useCategoryKey`, `useAdminMenuKey`.
-- `types/` — `Store`, `StoreDoc`, `User`, `StoreTag`, `StoreCategory` interfaces.
+- `types/` — `Store`, `StoreDoc`, `User`, `StoreTag`, `StoreCategory`, `StoreStatus` interfaces.
 - `utils/className.ts` and `lib/utils.ts` — both export `cn()` (clsx + tailwind-merge). Prefer `@/lib/utils`.
 - `mocks/` — Mockaroo-generated mock data for development.
 
 ### Firebase collections
 
 Environment variables switch between dev and prod Firestore collections (`mockStore`/`mockUser` vs `prodStore`/`prodUser`). Never hardcode collection names — use the env-driven constants.
+
+### Firestore write constraints
+
+`updateDoc` rejects `undefined` values — Firestore will throw at runtime if any field is `undefined`. Always pass `""` for optional string fields that are empty, never `field || undefined`.
 
 ## Styling rules
 

--- a/app/admin/store/list/page.tsx
+++ b/app/admin/store/list/page.tsx
@@ -1,31 +1,71 @@
 "use client";
 import { useEffect, useState } from "react";
 import { getStores } from "@/firebase/clientUtils";
-import { Space, Table, Tag } from "antd";
+import { updateStoreStatus } from "@/firebase/clientUtils";
+import { Space, Table, Tag, Button as AntButton } from "antd";
 import dayjs from "dayjs";
 import Link from "next/link";
 
 import type { TableProps } from "antd";
 import type { Store } from "@/types";
+import { STORE_STATUS, type StoreStatus } from "@/types";
 
-const columns: TableProps<Store>["columns"] = [
-  {
-    title: "Name",
-    dataIndex: "storeName",
-    key: "storeName",
-  },
-  {
-    title: "Price",
-    dataIndex: "price",
-    key: "price",
-    render: (_, record) => `${record.price} ${record.currency}`,
-  },
-  {
-    title: "Location",
-    dataIndex: "location",
-    key: "location",
-    render: (_, record) => {
-      return (
+const STATUS_COLOR: Record<StoreStatus, string> = {
+  pending: "orange",
+  approved: "green",
+  rejected: "red",
+};
+
+const STATUS_LABEL: Record<StoreStatus, string> = {
+  pending: "待審核",
+  approved: "已上架",
+  rejected: "已拒絕",
+};
+
+export default function List() {
+  const [stores, setStores] = useState<Store[]>([]);
+  const [updating, setUpdating] = useState<string | null>(null);
+
+  const fetchStores = async () => {
+    const fetchedStores = await getStores();
+    setStores(fetchedStores);
+  };
+
+  useEffect(() => {
+    fetchStores();
+  }, []);
+
+  const handleStatusChange = async (storeId: string, status: StoreStatus) => {
+    setUpdating(storeId + status);
+    try {
+      await updateStoreStatus(storeId, status);
+      setStores((previous) =>
+        previous.map((store) =>
+          store.id === storeId ? { ...store, status } : store,
+        ),
+      );
+    } finally {
+      setUpdating(null);
+    }
+  };
+
+  const columns: TableProps<Store>["columns"] = [
+    {
+      title: "Name",
+      dataIndex: "storeName",
+      key: "storeName",
+    },
+    {
+      title: "Price",
+      dataIndex: "price",
+      key: "price",
+      render: (_, record) => `${record.price} ${record.currency}`,
+    },
+    {
+      title: "Location",
+      dataIndex: "location",
+      key: "location",
+      render: (_, record) => (
         <div>
           <span>{`${record.city ?? "NoCity"}`}</span>
           <br />
@@ -33,59 +73,89 @@ const columns: TableProps<Store>["columns"] = [
           <br />
           <span>{`${record.location}`}</span>
         </div>
-      );
+      ),
     },
-  },
-  {
-    title: "Tags",
-    key: "tags",
-    dataIndex: "tags",
-    render: (_, { tags }) => (
-      <>
-        {tags?.map((tag) => {
-          let color = tag.length > 5 ? "geekblue" : "green";
-          return (
-            <Tag color={color} key={tag}>
-              {tag.toUpperCase()}
-            </Tag>
-          );
-        })}
-      </>
-    ),
-  },
-  {
-    title: "Created At",
-    dataIndex: "createTime",
-    key: "createTime",
-    render: (_, { createTime }) => {
-      return dayjs(createTime).format("YYYY-MM-DD h:mm:ss A");
+    {
+      title: "Tags",
+      key: "tags",
+      dataIndex: "tags",
+      render: (_, { tags }) => (
+        <>
+          {tags?.map((tag) => {
+            const color = tag.length > 5 ? "geekblue" : "green";
+            return (
+              <Tag color={color} key={tag}>
+                {tag.toUpperCase()}
+              </Tag>
+            );
+          })}
+        </>
+      ),
     },
-  },
-  {
-    title: "Action",
-    key: "action",
-    render: (_, record) => (
-      <Space size="middle">
-        <Link href={`/admin/store/edit/${record.id}`}>Edit</Link>
-        <a href={`/store/${record.id}`} target="_blank">
-          View
-        </a>
-        <a>Delete</a>
-      </Space>
-    ),
-  },
-];
+    {
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
+      filters: [
+        { text: "待審核", value: STORE_STATUS.PENDING },
+        { text: "已上架", value: STORE_STATUS.APPROVED },
+        { text: "已拒絕", value: STORE_STATUS.REJECTED },
+      ],
+      onFilter: (value, record) => record.status === value,
+      render: (_, { status }) => {
+        const resolvedStatus = status ?? STORE_STATUS.PENDING;
+        return (
+          <Tag color={STATUS_COLOR[resolvedStatus]}>
+            {STATUS_LABEL[resolvedStatus]}
+          </Tag>
+        );
+      },
+    },
+    {
+      title: "Created At",
+      dataIndex: "createTime",
+      key: "createTime",
+      render: (_, { createTime }) =>
+        dayjs(createTime).format("YYYY-MM-DD h:mm:ss A"),
+    },
+    {
+      title: "Action",
+      key: "action",
+      render: (_, record) => (
+        <Space size="middle" wrap>
+          <Link href={`/admin/store/edit/${record.id}`}>Edit</Link>
+          <a href={`/store/${record.id}`} target="_blank" rel="noreferrer">
+            View
+          </a>
+          <AntButton
+            size="small"
+            type="primary"
+            disabled={
+              record.status === STORE_STATUS.APPROVED ||
+              updating === record.id + STORE_STATUS.APPROVED
+            }
+            loading={updating === record.id + STORE_STATUS.APPROVED}
+            onClick={() => handleStatusChange(record.id, STORE_STATUS.APPROVED)}
+          >
+            通過
+          </AntButton>
+          <AntButton
+            size="small"
+            danger
+            disabled={
+              record.status === STORE_STATUS.REJECTED ||
+              updating === record.id + STORE_STATUS.REJECTED
+            }
+            loading={updating === record.id + STORE_STATUS.REJECTED}
+            onClick={() => handleStatusChange(record.id, STORE_STATUS.REJECTED)}
+          >
+            拒絕
+          </AntButton>
+        </Space>
+      ),
+    },
+  ];
 
-export default function List() {
-  const [stores, setStores] = useState<Store[]>([]);
-  useEffect(() => {
-    const fetchStores = async () => {
-      const stores = await getStores();
-      setStores(stores);
-      console.log(stores);
-    };
-    fetchStores();
-  }, []);
   return (
     <div className="p-[16px]">
       <Table columns={columns} dataSource={stores} rowKey={"id"} />

--- a/app/new/_components/NavAuthStatus.module.css
+++ b/app/new/_components/NavAuthStatus.module.css
@@ -1,0 +1,68 @@
+.avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--hand);
+  font-size: 0.875rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 1.5px solid var(--ink);
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+  text-transform: uppercase;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.wrapper {
+  position: relative;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 180px;
+  background: var(--paper);
+  border: 1.5px solid var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+}
+
+.dropdownEmail {
+  font-family: var(--hand);
+  font-size: 0.8125rem;
+  color: var(--muted);
+  padding: 0.625rem 0.875rem 0.5rem;
+  border-bottom: 1px solid var(--paper-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+.logoutBtn {
+  font-family: var(--hand);
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--accent);
+  background: transparent;
+  border: none;
+  padding: 0.625rem 0.875rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--paper-2);
+  }
+}

--- a/app/new/_components/NavAuthStatus.tsx
+++ b/app/new/_components/NavAuthStatus.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { onAuthStateChanged, signOut } from "firebase/auth";
+import type { User } from "firebase/auth";
+import NextLink from "next/link";
+import { auth } from "@/firebase/client";
+import Pill from "@/components/refactored/Pill";
+import styles from "./NavAuthStatus.module.css";
+
+function getInitial(user: User): string {
+  if (user.displayName) return user.displayName[0];
+  if (user.email) return user.email[0];
+  return "?";
+}
+
+export default function NavAuthStatus() {
+  const [user, setUser] = useState<User | null>(null);
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, setUser);
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  async function handleLogout() {
+    await signOut(auth);
+    setOpen(false);
+  }
+
+  if (!user) {
+    return (
+      <NextLink href="/new/login" style={{ textDecoration: "none" }}>
+        <Pill>登入</Pill>
+      </NextLink>
+    );
+  }
+
+  return (
+    <div className={styles.wrapper} ref={wrapperRef}>
+      <button
+        type="button"
+        className={styles.avatar}
+        onClick={() => setOpen((previous) => !previous)}
+        aria-label="帳號選單"
+      >
+        {getInitial(user)}
+      </button>
+
+      {open && (
+        <div className={styles.dropdown}>
+          <span className={styles.dropdownEmail}>
+            {user.displayName ?? user.email}
+          </span>
+          <button
+            type="button"
+            className={styles.logoutBtn}
+            onClick={handleLogout}
+          >
+            登出
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/new/_components/SellButton.tsx
+++ b/app/new/_components/SellButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { auth } from "@/firebase/client";
+import Button from "@/components/refactored/Button";
+
+export default function SellButton() {
+  const router = useRouter();
+
+  function handleClick() {
+    if (auth.currentUser) {
+      router.push("/new/sell");
+    } else {
+      router.push("/new/login?redirect=/new/sell");
+    }
+  }
+
+  return (
+    <Button variant="mus" className="px-2 py-1 text-xs" onClick={handleClick}>
+      + 限時免費刊登
+    </Button>
+  );
+}

--- a/app/new/_components/SiteNav.tsx
+++ b/app/new/_components/SiteNav.tsx
@@ -1,9 +1,8 @@
 import Logo from "./Logo";
-import Pill from "@/components/refactored/Pill";
 import Link from "@/components/refactored/Link";
 import SellButton from "./SellButton";
+import NavAuthStatus from "./NavAuthStatus";
 import { cn } from "@/lib/utils";
-import NextLink from "next/link";
 
 const navLinks = [
   { label: "我要找店", href: "/new/store-list" },
@@ -39,9 +38,7 @@ export default function SiteNav({ activeLink }: { activeLink?: string }) {
         ))}
       </ul>
       <div className="flex items-center gap-2">
-        <NextLink href="/new/login" style={{ textDecoration: "none" }}>
-          <Pill>登入</Pill>
-        </NextLink>
+        <NavAuthStatus />
         <SellButton />
       </div>
     </nav>

--- a/app/new/_components/SiteNav.tsx
+++ b/app/new/_components/SiteNav.tsx
@@ -1,7 +1,7 @@
 import Logo from "./Logo";
 import Pill from "@/components/refactored/Pill";
-import Button from "@/components/refactored/Button";
 import Link from "@/components/refactored/Link";
+import SellButton from "./SellButton";
 import { cn } from "@/lib/utils";
 import NextLink from "next/link";
 
@@ -42,9 +42,7 @@ export default function SiteNav({ activeLink }: { activeLink?: string }) {
         <NextLink href="/new/login" style={{ textDecoration: "none" }}>
           <Pill>登入</Pill>
         </NextLink>
-        <Button variant="mus" className="px-2 py-1 text-xs">
-          + 限時免費刊登
-        </Button>
+        <SellButton />
       </div>
     </nav>
   );

--- a/app/new/login/_components/LoginForm.tsx
+++ b/app/new/login/_components/LoginForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { auth } from "@/firebase/client";
 import Button from "@/components/refactored/Button";
@@ -21,6 +21,8 @@ const AUTH_ERRORS: Record<string, string> = {
 
 export default function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectPath = searchParams.get("redirect") ?? "/new/store-list";
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -33,7 +35,7 @@ export default function LoginForm() {
     setLoading(true);
     try {
       await signInWithEmailAndPassword(auth, email, password);
-      router.push("/new/store-list");
+      router.push(redirectPath);
     } catch (err) {
       const code = (err as { code?: string }).code ?? "";
       setError(AUTH_ERRORS[code] ?? "發生未知錯誤，請再試一次");

--- a/app/new/login/page.tsx
+++ b/app/new/login/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import AuthNav from "../_components/AuthNav";
 import LoginForm from "./_components/LoginForm";
 import styles from "./page.module.css";
@@ -7,7 +8,9 @@ export default function LoginPage() {
     <>
       <AuthNav variant="login" />
       <main className={styles.wrapper}>
-        <LoginForm />
+        <Suspense>
+          <LoginForm />
+        </Suspense>
       </main>
     </>
   );

--- a/app/new/sell/_components/SellForm.module.css
+++ b/app/new/sell/_components/SellForm.module.css
@@ -1,0 +1,177 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sectionTitle {
+  font-family: var(--display);
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--ink);
+  border-bottom: 1.5px solid var(--ink);
+  padding-bottom: 0.375rem;
+  margin: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.label {
+  font-family: var(--hand);
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--ink-2);
+}
+
+.optionalBadge {
+  font-weight: 400;
+  color: var(--muted);
+  font-size: 0.75rem;
+  margin-left: 0.25rem;
+}
+
+.select {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: var(--paper);
+  border: 1.5px solid var(--ink);
+  font-family: var(--hand);
+  font-size: 0.9375rem;
+  color: var(--ink);
+  outline: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%231c1a17' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  padding-right: 2.25rem;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+
+  &:focus {
+    border-color: var(--accent);
+    box-shadow: 3px 3px 0 var(--accent);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.textarea {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: var(--paper);
+  border: 1.5px solid var(--ink);
+  font-family: var(--hand);
+  font-size: 0.9375rem;
+  color: var(--ink);
+  outline: none;
+  resize: vertical;
+  min-height: 100px;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+
+  &::placeholder {
+    color: var(--muted);
+  }
+
+  &:focus {
+    border-color: var(--accent);
+    box-shadow: 3px 3px 0 var(--accent);
+  }
+}
+
+.checkboxGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.625rem;
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-family: var(--hand);
+  font-size: 0.9rem;
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.checkbox {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.checkboxLabelDisabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.readonlyNote {
+  font-family: var(--hand);
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin: 0.125rem 0 0;
+}
+
+.errorMsg {
+  font-family: var(--hand);
+  font-size: 0.875rem;
+  color: var(--accent);
+  margin: 0;
+}
+
+.successBox {
+  border: 1.5px solid var(--accent-2);
+  background: color-mix(in srgb, var(--accent-2) 8%, var(--paper));
+  padding: 1.25rem;
+  font-family: var(--hand);
+  color: var(--accent-2);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+}
+
+.loadingWrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+}
+
+.spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 2.5px solid var(--paper-3);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/app/new/sell/_components/SellForm.tsx
+++ b/app/new/sell/_components/SellForm.tsx
@@ -5,8 +5,12 @@ import { useRouter } from "next/navigation";
 import { onAuthStateChanged } from "firebase/auth";
 import type { User as FirebaseUser } from "firebase/auth";
 import { auth } from "@/firebase/client";
-import { getUserById, editUserById } from "@/firebase/clientUtils";
-import { createStoreDoc } from "@/firebase/clientUtils";
+import {
+  getUserById,
+  editUserById,
+  createStoreDoc,
+} from "@/firebase/clientUtils";
+import StoreImageUpload from "./StoreImageUpload";
 import {
   getStoreCities,
   getStoreDistrictByCity,
@@ -62,7 +66,7 @@ export default function SellForm() {
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
+  const [createdStoreId, setCreatedStoreId] = useState<string | null>(null);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
@@ -130,14 +134,14 @@ export default function SellForm() {
     }
 
     try {
-      await createStoreDoc({
+      const storeRef = await createStoreDoc({
         ...store,
         price: Number(store.price),
         currency: "TWD",
         user: authUser.uid,
         images: [],
       } as unknown as Store);
-      setSuccess(true);
+      setCreatedStoreId(storeRef.id);
     } catch {
       setError("刊登店面失敗，請稍後再試");
     } finally {
@@ -153,20 +157,13 @@ export default function SellForm() {
     );
   }
 
-  if (success) {
+  if (createdStoreId) {
     return (
       <Card className="w-full max-w-[640px]">
-        <div className={styles.successBox}>
-          <strong>刊登成功！</strong>
-          <br />
-          我們已收到您的店面資料，審核後將盡快上架。感謝您使用 Bezold
-          限時免費刊登服務。
-        </div>
-        <div className={`${styles.actions} mt-4`}>
-          <Button onClick={() => router.push("/new/store-list")}>
-            瀏覽店面
-          </Button>
-        </div>
+        <StoreImageUpload
+          storeId={createdStoreId}
+          onDone={() => router.push("/new/store-list")}
+        />
       </Card>
     );
   }

--- a/app/new/sell/_components/SellForm.tsx
+++ b/app/new/sell/_components/SellForm.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { onAuthStateChanged } from "firebase/auth";
+import type { User as FirebaseUser } from "firebase/auth";
+import { auth } from "@/firebase/client";
+import { getUserById, editUserById } from "@/firebase/clientUtils";
+import { createStoreDoc } from "@/firebase/clientUtils";
+import {
+  getStoreCities,
+  getStoreDistrictByCity,
+} from "@/constant/StoreLocation";
+import { STORE_TAGS } from "@/constant/storeTags";
+import { STORE_CATEGORIES } from "@/constant/storeType";
+import { genDefaultStore } from "@/utils/store";
+import FormField from "@/components/refactored/FormField";
+import Button from "@/components/refactored/Button";
+import Card from "@/components/refactored/Card";
+import type { Store } from "@/types";
+import styles from "./SellForm.module.css";
+
+interface StoreFields {
+  storeName: string;
+  city: string;
+  district: string;
+  location: string;
+  description: string;
+  price: string;
+  tags: string[];
+  category: string;
+}
+
+interface BossFields {
+  userName: string;
+  phone: string;
+  email: string;
+  lineId: string;
+  remark: string;
+}
+
+export default function SellForm() {
+  const router = useRouter();
+  const [authUser, setAuthUser] = useState<FirebaseUser | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+
+  const [store, setStore] = useState<StoreFields>({
+    ...genDefaultStore(),
+    city: "",
+    district: "",
+    tags: [],
+    category: "",
+    price: String(genDefaultStore().price),
+  });
+  const [boss, setBoss] = useState<BossFields>({
+    userName: "",
+    phone: "",
+    email: "",
+    lineId: "",
+    remark: "",
+  });
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+      if (!firebaseUser) {
+        router.push("/new/login?redirect=/new/sell");
+        return;
+      }
+      setAuthUser(firebaseUser);
+
+      const userDoc = await getUserById(firebaseUser.uid);
+      setBoss({
+        userName: userDoc?.userName ?? "",
+        phone: userDoc?.phone ?? "",
+        email: firebaseUser.email ?? "",
+        lineId: userDoc?.lineId ?? "",
+        remark: userDoc?.remark ?? "",
+      });
+
+      setAuthLoading(false);
+    });
+    return () => unsubscribe();
+  }, [router]);
+
+  function setStoreField<K extends keyof StoreFields>(
+    key: K,
+    value: StoreFields[K],
+  ) {
+    setStore((previous) => ({ ...previous, [key]: value }));
+  }
+
+  function setBossField<K extends keyof BossFields>(
+    key: K,
+    value: BossFields[K],
+  ) {
+    setBoss((previous) => ({ ...previous, [key]: value }));
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!authUser) return;
+
+    if (!store.storeName || !store.location || !store.description) {
+      setError("請填寫店面名稱、地址與描述");
+      return;
+    }
+    if (!boss.userName || !boss.phone) {
+      setError("請填寫聯絡人姓名與電話");
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await editUserById(authUser.uid, {
+        userName: boss.userName,
+        phone: boss.phone,
+        lineId: boss.lineId,
+        remark: boss.remark,
+      });
+    } catch (err) {
+      setError("更新聯絡人資料失敗，請稍後再試");
+      setSubmitting(false);
+      return;
+    }
+
+    try {
+      await createStoreDoc({
+        ...store,
+        price: Number(store.price),
+        currency: "TWD",
+        user: authUser.uid,
+        images: [],
+      } as unknown as Store);
+      setSuccess(true);
+    } catch {
+      setError("刊登店面失敗，請稍後再試");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (authLoading) {
+    return (
+      <div className={styles.loadingWrap}>
+        <div className={styles.spinner} />
+      </div>
+    );
+  }
+
+  if (success) {
+    return (
+      <Card className="w-full max-w-[640px]">
+        <div className={styles.successBox}>
+          <strong>刊登成功！</strong>
+          <br />
+          我們已收到您的店面資料，審核後將盡快上架。感謝您使用 Bezold
+          限時免費刊登服務。
+        </div>
+        <div className={`${styles.actions} mt-4`}>
+          <Button onClick={() => router.push("/new/store-list")}>
+            瀏覽店面
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  const cities = getStoreCities();
+  const districts = getStoreDistrictByCity(store.city);
+
+  return (
+    <Card className="w-full max-w-[640px]">
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>店面資料</h2>
+
+          <FormField
+            id="storeName"
+            label="店面名稱"
+            placeholder="例：台北東區手搖飲料店"
+            value={store.storeName}
+            onChange={(event) => setStoreField("storeName", event.target.value)}
+          />
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="city">
+              縣市
+            </label>
+            <select
+              id="city"
+              className={styles.select}
+              value={store.city}
+              onChange={(event) => {
+                setStoreField("city", event.target.value);
+                setStoreField("district", "");
+              }}
+            >
+              <option value="">請選擇縣市</option>
+              {cities.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="district">
+              行政區
+            </label>
+            <select
+              id="district"
+              className={styles.select}
+              value={store.district}
+              onChange={(event) =>
+                setStoreField("district", event.target.value)
+              }
+              disabled={!store.city}
+            >
+              <option value="">請選擇行政區</option>
+              {districts.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <FormField
+            id="location"
+            label="詳細地址"
+            placeholder="例：忠孝東路四段 123 號"
+            value={store.location}
+            onChange={(event) => setStoreField("location", event.target.value)}
+          />
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="description">
+              店面描述
+            </label>
+            <textarea
+              id="description"
+              className={styles.textarea}
+              placeholder="請描述店面狀況、坪數、月租、頂讓原因等資訊"
+              value={store.description}
+              onChange={(event) =>
+                setStoreField("description", event.target.value)
+              }
+            />
+          </div>
+
+          <FormField
+            id="price"
+            label="頂讓金（TWD）"
+            placeholder="例：500000"
+            value={store.price}
+            onChange={(event) => setStoreField("price", event.target.value)}
+          />
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="category">
+              類別
+            </label>
+            <select
+              id="category"
+              className={styles.select}
+              value={store.category}
+              onChange={(event) =>
+                setStoreField("category", event.target.value)
+              }
+            >
+              <option value="">請選擇類別</option>
+              {STORE_CATEGORIES.map((cat) => (
+                <option key={cat.key} value={cat.key}>
+                  {cat.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className={styles.field}>
+            <span className={styles.label}>標籤</span>
+            <div className={styles.checkboxGroup}>
+              {STORE_TAGS.map((tag) => (
+                <label
+                  key={tag.key}
+                  className={`${styles.checkboxLabel} ${styles.checkboxLabelDisabled}`}
+                >
+                  <input
+                    type="checkbox"
+                    className={styles.checkbox}
+                    checked={false}
+                    disabled
+                    readOnly
+                  />
+                  {tag.label}
+                </label>
+              ))}
+            </div>
+            <p className={styles.readonlyNote}>標籤由管理員審核後設定</p>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>聯絡人資料</h2>
+
+          <FormField
+            id="userName"
+            label="姓名"
+            placeholder="請輸入姓名"
+            value={boss.userName}
+            onChange={(event) => setBossField("userName", event.target.value)}
+          />
+
+          <FormField
+            id="phone"
+            label="電話"
+            placeholder="例：0912345678"
+            value={boss.phone}
+            onChange={(event) => setBossField("phone", event.target.value)}
+          />
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="email">
+              電子信箱
+            </label>
+            <input
+              id="email"
+              type="email"
+              className={styles.select}
+              value={boss.email}
+              readOnly
+              style={{ cursor: "default", backgroundImage: "none" }}
+            />
+            <p className={styles.readonlyNote}>登入帳號的電子信箱，無法修改</p>
+          </div>
+
+          <FormField
+            id="lineId"
+            label="Line ID"
+            placeholder="選填"
+            value={boss.lineId}
+            onChange={(event) => setBossField("lineId", event.target.value)}
+          />
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="remark">
+              備註
+              <span className={styles.optionalBadge}>（選填）</span>
+            </label>
+            <textarea
+              id="remark"
+              className={styles.textarea}
+              placeholder="其他補充資訊"
+              value={boss.remark}
+              onChange={(event) => setBossField("remark", event.target.value)}
+            />
+          </div>
+        </section>
+
+        {error && <p className={styles.errorMsg}>{error}</p>}
+
+        <div className={styles.actions}>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => router.push("/new/store-list")}
+          >
+            取消
+          </Button>
+          <Button type="submit" variant="mus" disabled={submitting}>
+            {submitting ? "提交中..." : "免費刊登"}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/app/new/sell/_components/SellForm.tsx
+++ b/app/new/sell/_components/SellForm.tsx
@@ -21,7 +21,7 @@ import { genDefaultStore } from "@/utils/store";
 import FormField from "@/components/refactored/FormField";
 import Button from "@/components/refactored/Button";
 import Card from "@/components/refactored/Card";
-import type { Store } from "@/types";
+import { type Store, STORE_STATUS } from "@/types";
 import styles from "./SellForm.module.css";
 
 interface StoreFields {
@@ -140,6 +140,7 @@ export default function SellForm() {
         currency: "TWD",
         user: authUser.uid,
         images: [],
+        status: STORE_STATUS.PENDING,
       } as unknown as Store);
       setCreatedStoreId(storeRef.id);
     } catch {

--- a/app/new/sell/_components/StoreImageUpload.module.css
+++ b/app/new/sell/_components/StoreImageUpload.module.css
@@ -1,0 +1,154 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.heading {
+  font-family: var(--display);
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--ink);
+  border-bottom: 1.5px solid var(--ink);
+  padding-bottom: 0.375rem;
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.imageCount {
+  font-family: var(--hand);
+  font-size: 0.8125rem;
+  font-weight: 400;
+  color: var(--muted);
+}
+
+.successNote {
+  font-family: var(--hand);
+  font-size: 0.9rem;
+  color: var(--accent-2);
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border: 1.5px solid var(--accent-2);
+  background: color-mix(in srgb, var(--accent-2) 6%, var(--paper));
+}
+
+.imageGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.imageRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.thumbnail {
+  width: 120px;
+  height: 90px;
+  object-fit: cover;
+  border: 1.5px solid var(--ink);
+  flex-shrink: 0;
+}
+
+.deleteBtn {
+  padding: 0.25rem 0.625rem;
+  font-family: var(--hand);
+  font-size: 0.8125rem;
+  background: var(--paper);
+  border: 1.5px solid var(--ink);
+  color: var(--accent);
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--paper-2);
+  }
+}
+
+.pickerArea {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.previewRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.previewThumb {
+  width: 120px;
+  height: 90px;
+  object-fit: cover;
+  border: 1.5px solid var(--accent);
+  flex-shrink: 0;
+}
+
+.previewName {
+  font-family: var(--hand);
+  font-size: 0.875rem;
+  color: var(--ink-2);
+  word-break: break-all;
+}
+
+.fileInputWrap {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.selectBtn {
+  padding: 0.5rem 1rem;
+  font-family: var(--hand);
+  font-size: 0.875rem;
+  font-weight: 700;
+  background: var(--paper);
+  border: 1.5px solid var(--ink);
+  color: var(--ink);
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover:not(:disabled) {
+    background: var(--paper-2);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.uploadBtn {
+  padding: 0.5rem 1rem;
+  font-family: var(--hand);
+  font-size: 0.875rem;
+  font-weight: 700;
+  background: var(--ink);
+  border: 1.5px solid var(--ink);
+  color: var(--paper);
+  cursor: pointer;
+  transition: opacity 0.15s;
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.5rem;
+}
+
+.errorMsg {
+  font-family: var(--hand);
+  font-size: 0.875rem;
+  color: var(--accent);
+  margin: 0;
+}

--- a/app/new/sell/_components/StoreImageUpload.tsx
+++ b/app/new/sell/_components/StoreImageUpload.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useRef, useState } from "react";
+import Image from "next/image";
+import {
+  uploadStoreImageByFile,
+  delateStoreImage,
+  getImageByPath,
+} from "@/firebase/clientUtils";
+import Button from "@/components/refactored/Button";
+import styles from "./StoreImageUpload.module.css";
+
+interface UploadedImage {
+  path: string;
+  url: string;
+}
+
+export default function StoreImageUpload({
+  storeId,
+  onDone,
+}: {
+  storeId: string;
+  onDone: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const MAX_IMAGES = 5;
+  const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([]);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleUpload() {
+    if (!pendingFile) return;
+    setUploading(true);
+    setError(null);
+    try {
+      const snapshot = await uploadStoreImageByFile(storeId, pendingFile);
+      const url = await getImageByPath(snapshot.metadata.fullPath);
+      setUploadedImages((previous) => [
+        ...previous,
+        { path: snapshot.metadata.fullPath, url },
+      ]);
+      setPendingFile(null);
+    } catch {
+      setError("上傳失敗，請稍後再試");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleDelete(path: string) {
+    setError(null);
+    try {
+      await delateStoreImage(storeId, path);
+      setUploadedImages((previous) =>
+        previous.filter((image) => image.path !== path),
+      );
+    } catch {
+      setError("刪除失敗，請稍後再試");
+    }
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <h2 className={styles.heading}>
+        上傳店面照片
+        <span className={styles.imageCount}>
+          {uploadedImages.length} / {MAX_IMAGES}
+        </span>
+      </h2>
+
+      <p className={styles.successNote}>
+        店面資料已送出！可上傳照片讓買家更了解您的店面，也可直接略過。
+      </p>
+
+      {uploadedImages.length > 0 && (
+        <div className={styles.imageGrid}>
+          {uploadedImages.map(({ path, url }) => (
+            <div key={path} className={styles.imageRow}>
+              <Image
+                src={url}
+                width={120}
+                height={90}
+                alt="store image"
+                className={styles.thumbnail}
+              />
+              <button
+                type="button"
+                className={styles.deleteBtn}
+                onClick={() => handleDelete(path)}
+              >
+                刪除
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className={styles.pickerArea}>
+        {pendingFile ? (
+          <div className={styles.previewRow}>
+            <Image
+              src={URL.createObjectURL(pendingFile)}
+              width={120}
+              height={90}
+              alt="preview"
+              className={styles.previewThumb}
+            />
+            <span className={styles.previewName}>{pendingFile.name}</span>
+          </div>
+        ) : null}
+
+        <div className={styles.fileInputWrap}>
+          <button
+            type="button"
+            className={styles.selectBtn}
+            disabled={uploadedImages.length >= MAX_IMAGES}
+            onClick={() => inputRef.current?.click()}
+          >
+            {pendingFile ? "重新選擇" : "選擇照片"}
+          </button>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={(event) => {
+              if (event.target.files?.[0]) {
+                setPendingFile(event.target.files[0]);
+                setError(null);
+              }
+            }}
+          />
+          <button
+            type="button"
+            className={styles.uploadBtn}
+            disabled={!pendingFile || uploading}
+            onClick={handleUpload}
+          >
+            {uploading ? "上傳中..." : "上傳"}
+          </button>
+        </div>
+      </div>
+
+      {error && <p className={styles.errorMsg}>{error}</p>}
+
+      <div className={styles.actions}>
+        <Button variant="mus" onClick={onDone}>
+          {uploadedImages.length > 0 ? "完成刊登" : "略過，完成刊登"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/new/sell/page.module.css
+++ b/app/new/sell/page.module.css
@@ -1,0 +1,29 @@
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2.5rem 1.25rem 4rem;
+  gap: 1.75rem;
+}
+
+.heading {
+  font-family: var(--display);
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--ink);
+  margin: 0;
+  text-align: center;
+
+  & strong {
+    color: var(--accent);
+  }
+}
+
+.subheading {
+  font-family: var(--hand);
+  font-size: 0.9375rem;
+  color: var(--muted);
+  margin: 0;
+  text-align: center;
+}

--- a/app/new/sell/page.tsx
+++ b/app/new/sell/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import SiteNav from "@/app/new/_components/SiteNav";
+import SiteFooter from "@/app/new/_components/SiteFooter";
+import SellForm from "./_components/SellForm";
+import styles from "./page.module.css";
+
+export const metadata: Metadata = {
+  title: "頂讓.tw — 限時免費刊登",
+  description: "免費刊登您的店面，快速找到合適買家。",
+};
+
+export default function SellPage() {
+  return (
+    <>
+      <SiteNav activeLink="我要頂出" />
+      <main className={styles.main}>
+        <h1 className={styles.heading}>
+          限時<strong>免費刊登</strong>
+        </h1>
+        <p className={styles.subheading}>
+          填寫以下資料，審核後即可上架。完全免費，沒有中間人。
+        </p>
+        <SellForm />
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/app/new/store-list/_components/ResultsArea.tsx
+++ b/app/new/store-list/_components/ResultsArea.tsx
@@ -9,7 +9,7 @@ import Dropdown, {
   type DropdownOption,
 } from "@/components/refactored/Dropdown";
 import { type PillVariant } from "@/components/refactored/Pill";
-import { type Store } from "@/types";
+import { type Store, STORE_STATUS } from "@/types";
 import { STORE_CATEGORIES } from "@/constant/storeType";
 import {
   TAG_DISPLAY,
@@ -76,14 +76,19 @@ function sortStores(stores: Store[], sort: string): Store[] {
 
 export default function ResultsArea({ stores }: { stores: Store[] }) {
   const [sort, setSort] = useState("newest");
-  const sortedStores = sortStores(stores, sort);
+  const approvedStores = stores.filter(
+    (store) => store.status === STORE_STATUS.APPROVED,
+  );
+  const sortedStores = sortStores(approvedStores, sort);
 
   return (
     <div className={styles.area}>
       <div className={styles.controlbar}>
         <div className={styles.count}>
           <span className={styles.countNum}>
-            共 <span className={styles.countRange}>{stores.length}</span> 間
+            共{" "}
+            <span className={styles.countRange}>{approvedStores.length}</span>{" "}
+            間
           </span>
         </div>
         <Dropdown

--- a/firebase/clientUtils/store.ts
+++ b/firebase/clientUtils/store.ts
@@ -12,7 +12,7 @@ import {
 } from "firebase/firestore";
 import { db } from "@/firebase/client";
 
-import type { Store, StoreDoc } from "@/types";
+import type { Store, StoreDoc, StoreStatus } from "@/types";
 import { COLLECTIONS } from "@/firebase/constants";
 
 const COLLECTION = COLLECTIONS.STORE;
@@ -83,8 +83,16 @@ export const editStoreById = async (
   editedStore: Partial<Store>,
 ) => {
   const docRef = doc(db, COLLECTION, storeId);
-  const docSnap = await updateDoc(docRef, {
+  await updateDoc(docRef, {
     ...editedStore,
     updateTime: serverTimestamp(),
   });
+};
+
+export const updateStoreStatus = async (
+  storeId: Store["id"],
+  status: StoreStatus,
+) => {
+  const docRef = doc(db, COLLECTION, storeId);
+  await updateDoc(docRef, { status, updateTime: serverTimestamp() });
 };

--- a/types/Store.ts
+++ b/types/Store.ts
@@ -1,6 +1,7 @@
 import { User } from "./User";
 import type { Timestamp } from "firebase/firestore";
 import { StoreTag } from "@/types/StoreTags";
+import { StoreStatus } from "@/types/StoreStatus";
 
 // * types in client
 export interface Store {
@@ -19,6 +20,7 @@ export interface Store {
   userInfo?: User;
   city?: string; // TODO: will not be option in the future
   district?: string; // TODO: will not be option in the future
+  status?: StoreStatus;
 }
 
 // * types in firestore doc
@@ -37,4 +39,5 @@ export interface StoreDoc {
   userInfo?: User;
   city?: string; // TODO: will not be option in the future
   district?: string; // TODO: will not be option in the future
+  status?: StoreStatus;
 }

--- a/types/StoreStatus.ts
+++ b/types/StoreStatus.ts
@@ -1,0 +1,7 @@
+export const STORE_STATUS = {
+  PENDING: "pending",
+  APPROVED: "approved",
+  REJECTED: "rejected",
+} as const;
+
+export type StoreStatus = (typeof STORE_STATUS)[keyof typeof STORE_STATUS];

--- a/types/index.ts
+++ b/types/index.ts
@@ -2,3 +2,4 @@ export * from "./Store";
 export * from "./User";
 export * from "./StoreTags";
 export * from "./StoreCategory";
+export * from "./StoreStatus";


### PR DESCRIPTION
## Summary

Implements the full 限時免費刊登 (free limited-time listing) flow for sellers on the `/new/` public-facing site, plus a store status system for admin moderation.

## What changed

### Auth-gated seller listing form (`/new/sell`)
- New page with store info + contact info form, matching the field set of `/admin/store/create`
- `SellButton` in `SiteNav` checks `auth.currentUser` on click — routes to `/new/sell` if logged in, or `/new/login?redirect=/new/sell` if not
- `LoginForm` now reads `?redirect` from search params and navigates there after successful login
- Tags field is permanently disabled for normal users (admin-only via the edit flow)
- Contact info (name, phone, email) is pre-filled from the user's Firebase Auth + Firestore doc

### Image upload step (`/new/sell` — post-submission)
- After store is created, the form transitions to a `StoreImageUpload` component
- Users can upload up to 5 images one at a time, with a live `0 / 5` counter
- Each uploaded image is displayed with a delete button
- "略過，完成刊登" skips; "完成刊登" navigates to store list

### Nav auth status (`SiteNav`)
- Replaces the static "登入" pill with a `NavAuthStatus` client component
- Logged out → shows 登入 pill
- Logged in → shows avatar circle (user initial), click to open dropdown with email + 登出 button

### Store status system
- New `StoreStatus` type: `pending | approved | rejected`
- Stores submitted via `/new/sell` default to `status: pending`
- `/new/store-list` filters to approved stores only (frontend, in `ResultsArea`)
- Admin store list (`/admin/store/list`) gains a Status column (coloured tag, filterable) and 通過 / 拒絕 action buttons with loading state

## Reviewer notes

- Existing stores in Firestore have no `status` field — they will not appear in `/new/store-list` until approved via the admin panel
- Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)