### PR TITLE
feat(my-listings): seller dashboard to track listing status

### DIFF
--- a/.claude/skills/cleanup-worktree/SKILL.md
+++ b/.claude/skills/cleanup-worktree/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: cleanup-worktree
+description: Removes the git worktree that the current session is running in, and optionally deletes its branch. Use when the user says "cleanup worktree", "remove worktree", "delete this worktree", "clean up the branch", or similar phrases at the end of a session.
+---
+
+## Goal
+
+Remove the current session's worktree from the main repo and optionally delete its branch.
+
+## Steps
+
+1. **Detect the current worktree path** — the working directory of this session is the worktree root.
+
+2. **Find the main repo** — run `git worktree list` from the worktree to identify the main repo path (the first entry).
+
+3. **Check for uncommitted changes** — run `git status`. If any exist, warn the user and stop. Never remove a worktree with uncommitted work.
+
+4. **Remove the worktree** — from the main repo directory, run:
+
+   ```bash
+   git worktree remove <worktree-path> --force
+   ```
+
+5. **Offer to delete the branch** — ask the user if they also want to delete the branch. If yes:
+
+   ```bash
+   git branch -d <branch-name>
+   ```
+
+   Use `-D` only if the branch is unmerged and the user explicitly confirms.
+
+6. **Confirm** — report what was removed.

--- a/app/new/_components/NavAuthStatus.module.css
+++ b/app/new/_components/NavAuthStatus.module.css
@@ -50,6 +50,22 @@
   max-width: 200px;
 }
 
+.dropdownLink {
+  font-family: var(--hand);
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--ink);
+  text-decoration: none;
+  padding: 0.625rem 0.875rem;
+  display: block;
+  transition: background 0.15s;
+  border-bottom: 1px solid var(--paper-3);
+
+  &:hover {
+    background: var(--paper-2);
+  }
+}
+
 .logoutBtn {
   font-family: var(--hand);
   font-size: 0.875rem;

--- a/app/new/_components/NavAuthStatus.tsx
+++ b/app/new/_components/NavAuthStatus.tsx
@@ -66,6 +66,13 @@ export default function NavAuthStatus() {
           <span className={styles.dropdownEmail}>
             {user.displayName ?? user.email}
           </span>
+          <NextLink
+            href="/new/my-listings"
+            className={styles.dropdownLink}
+            onClick={() => setOpen(false)}
+          >
+            我的刊登
+          </NextLink>
           <button
             type="button"
             className={styles.logoutBtn}

--- a/app/new/my-listings/_components/ListingCard.module.css
+++ b/app/new/my-listings/_components/ListingCard.module.css
@@ -1,0 +1,98 @@
+.card {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  background: var(--paper);
+  border: 1.5px solid var(--ink);
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+.thumb {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  flex-shrink: 0;
+  background: var(--paper-3);
+  overflow: hidden;
+}
+
+.img {
+  object-fit: cover;
+}
+
+.thumbPlaceholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--hand);
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.name {
+  font-family: var(--hand);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ink);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.meta {
+  font-family: var(--hand);
+  font-size: 0.8125rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.price {
+  font-family: var(--hand);
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--accent);
+  margin: 0;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: auto;
+}
+
+.date {
+  font-family: var(--hand);
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.viewLink {
+  font-family: var(--hand);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--accent-2);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/app/new/my-listings/_components/ListingCard.tsx
+++ b/app/new/my-listings/_components/ListingCard.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import NextLink from "next/link";
+import { ref, getDownloadURL } from "firebase/storage";
+import { storage } from "@/firebase/client";
+import { type Store, STORE_STATUS } from "@/types";
+import { STORE_CATEGORIES } from "@/constant/storeType";
+import StatusBadge from "./StatusBadge";
+import styles from "./ListingCard.module.css";
+
+function formatDate(date: Date): string {
+  const diffMs = Date.now() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return "今天";
+  if (diffDays === 1) return "昨天";
+  if (diffDays < 30) return `${diffDays} 天前`;
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `${diffMonths} 個月前`;
+  return `${Math.floor(diffMonths / 12)} 年前`;
+}
+
+export default function ListingCard({ store }: { store: Store }) {
+  const rawPath = store.images?.[0] ?? null;
+  const [coverImage, setCoverImage] = useState<string | null>(
+    rawPath?.startsWith("http") ? rawPath : null,
+  );
+
+  useEffect(() => {
+    if (!rawPath || rawPath.startsWith("http")) return;
+    getDownloadURL(ref(storage, rawPath))
+      .then(setCoverImage)
+      .catch(() => {});
+  }, [rawPath]);
+  const categoryEntry = STORE_CATEGORIES.find(
+    (cat) => cat.key === store.category,
+  );
+  const categoryLabel = categoryEntry?.label ?? "";
+  const location = [store.city, store.district].filter(Boolean).join(" · ");
+  const price = `NT$ ${Math.round(store.price / 10000)} 萬`;
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.thumb}>
+        {coverImage ? (
+          <Image src={coverImage} fill alt="店面照" className={styles.img} />
+        ) : (
+          <span className={styles.thumbPlaceholder}>店面照</span>
+        )}
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.top}>
+          <h3 className={styles.name}>{store.storeName}</h3>
+          <StatusBadge status={store.status ?? STORE_STATUS.PENDING} />
+        </div>
+
+        {(location || categoryLabel) && (
+          <p className={styles.meta}>
+            {[location, categoryLabel].filter(Boolean).join(" · ")}
+          </p>
+        )}
+
+        <p className={styles.price}>{price}</p>
+
+        <div className={styles.footer}>
+          <span className={styles.date}>{formatDate(store.createTime)}</span>
+          {store.status === STORE_STATUS.APPROVED && (
+            <NextLink
+              href={`/new/store/${store.id}`}
+              className={styles.viewLink}
+            >
+              查看刊登 →
+            </NextLink>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/new/my-listings/_components/MyListingsContent.module.css
+++ b/app/new/my-listings/_components/MyListingsContent.module.css
@@ -1,0 +1,58 @@
+.center {
+  display: flex;
+  justify-content: center;
+  padding: 4rem 0;
+}
+
+.spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 2.5px solid var(--paper-3);
+  border-top-color: var(--ink);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.emptyText {
+  font-family: var(--hand);
+  font-size: 1rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.emptyLink {
+  font-family: var(--hand);
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--accent);
+  text-decoration: none;
+  border: 1.5px solid var(--accent);
+  padding: 0.5rem 1.25rem;
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--accent);
+    color: var(--paper);
+  }
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/app/new/my-listings/_components/MyListingsContent.tsx
+++ b/app/new/my-listings/_components/MyListingsContent.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { onAuthStateChanged } from "firebase/auth";
+import NextLink from "next/link";
+import { auth } from "@/firebase/client";
+import { getStoresByUserId } from "@/firebase/clientUtils";
+import type { Store } from "@/types";
+import ListingCard from "./ListingCard";
+import styles from "./MyListingsContent.module.css";
+
+export default function MyListingsContent() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [stores, setStores] = useState<Store[]>([]);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (!user) {
+        router.push("/new/login?redirect=/new/my-listings");
+        return;
+      }
+      try {
+        const userStores = await getStoresByUserId(user.uid);
+        setStores(userStores);
+      } finally {
+        setLoading(false);
+      }
+    });
+    return () => unsubscribe();
+  }, [router]);
+
+  if (loading) {
+    return (
+      <div className={styles.center}>
+        <div className={styles.spinner} />
+      </div>
+    );
+  }
+
+  if (stores.length === 0) {
+    return (
+      <div className={styles.empty}>
+        <p className={styles.emptyText}>你還沒有刊登任何店面</p>
+        <NextLink href="/new/sell" className={styles.emptyLink}>
+          立即免費刊登 →
+        </NextLink>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.list}>
+      {stores.map((store) => (
+        <ListingCard key={store.id} store={store} />
+      ))}
+    </div>
+  );
+}

--- a/app/new/my-listings/_components/StatusBadge.module.css
+++ b/app/new/my-listings/_components/StatusBadge.module.css
@@ -1,0 +1,30 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.625rem;
+  border-radius: 999px;
+  font-family: var(--hand);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  border: 1.5px solid transparent;
+}
+
+.pending {
+  background: #fef9e2;
+  color: #9a7000;
+  border-color: var(--accent-3);
+}
+
+.approved {
+  background: #e4f2eb;
+  color: var(--accent-2);
+  border-color: var(--accent-2);
+}
+
+.rejected {
+  background: #faeae6;
+  color: var(--accent);
+  border-color: var(--accent);
+}

--- a/app/new/my-listings/_components/StatusBadge.tsx
+++ b/app/new/my-listings/_components/StatusBadge.tsx
@@ -1,0 +1,23 @@
+import { STORE_STATUS, type StoreStatus } from "@/types";
+import { cn } from "@/lib/utils";
+import styles from "./StatusBadge.module.css";
+
+const STATUS_LABEL: Record<StoreStatus, string> = {
+  [STORE_STATUS.PENDING]: "審核中",
+  [STORE_STATUS.APPROVED]: "刊登中",
+  [STORE_STATUS.REJECTED]: "未通過",
+};
+
+const STATUS_CLASS: Record<StoreStatus, string> = {
+  [STORE_STATUS.PENDING]: styles.pending,
+  [STORE_STATUS.APPROVED]: styles.approved,
+  [STORE_STATUS.REJECTED]: styles.rejected,
+};
+
+export default function StatusBadge({ status }: { status: StoreStatus }) {
+  return (
+    <span className={cn(styles.badge, STATUS_CLASS[status])}>
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}

--- a/app/new/my-listings/page.module.css
+++ b/app/new/my-listings/page.module.css
@@ -1,0 +1,26 @@
+.main {
+  flex: 1;
+  max-width: 760px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 2.5rem 1.25rem 4rem;
+}
+
+.header {
+  margin-bottom: 2rem;
+}
+
+.title {
+  font-family: var(--display);
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--ink);
+  margin: 0 0 0.375rem;
+}
+
+.subtitle {
+  font-family: var(--hand);
+  font-size: 0.9375rem;
+  color: var(--muted);
+  margin: 0;
+}

--- a/app/new/my-listings/page.tsx
+++ b/app/new/my-listings/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import LaunchBanner from "@/app/new/_components/LaunchBanner";
+import SiteNav from "@/app/new/_components/SiteNav";
+import SiteFooter from "@/app/new/_components/SiteFooter";
+import MyListingsContent from "./_components/MyListingsContent";
+import styles from "./page.module.css";
+
+export const metadata: Metadata = {
+  title: "頂讓.tw — 我的刊登",
+  description: "查看你提交的店面與審核狀態。",
+};
+
+export default function MyListingsPage() {
+  return (
+    <>
+      <LaunchBanner />
+      <SiteNav />
+      <main className={styles.main}>
+        <div className={styles.header}>
+          <h1 className={styles.title}>我的刊登</h1>
+          <p className={styles.subtitle}>查看你提交的店面與審核狀態</p>
+        </div>
+        <MyListingsContent />
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/app/new/sell/_components/SellForm.tsx
+++ b/app/new/sell/_components/SellForm.tsx
@@ -163,7 +163,7 @@ export default function SellForm() {
       <Card className="w-full max-w-[640px]">
         <StoreImageUpload
           storeId={createdStoreId}
-          onDone={() => router.push("/new/store-list")}
+          onDone={() => router.push("/new/my-listings")}
         />
       </Card>
     );

--- a/firebase/clientUtils/store.ts
+++ b/firebase/clientUtils/store.ts
@@ -9,6 +9,7 @@ import {
   Timestamp,
   query,
   orderBy,
+  where,
 } from "firebase/firestore";
 import { db } from "@/firebase/client";
 
@@ -95,4 +96,21 @@ export const updateStoreStatus = async (
 ) => {
   const docRef = doc(db, COLLECTION, storeId);
   await updateDoc(docRef, { status, updateTime: serverTimestamp() });
+};
+
+export const getStoresByUserId = async (userId: string) => {
+  const collectionRef = collection(db, COLLECTION).withConverter(
+    storeConverter,
+  );
+  const collectionQuery = query(
+    collectionRef,
+    where("user", "==", userId),
+    orderBy("createTime", "desc"),
+  );
+  const querySnapshot = await getDocs(collectionQuery);
+  const stores: Store[] = [];
+  querySnapshot.forEach((docSnap) => {
+    stores.push(docSnap.data());
+  });
+  return stores;
 };


### PR DESCRIPTION
Closes #22

## Summary

- Adds `/new/my-listings` — a private page where authenticated sellers can see all their submitted stores and current review status
- Adds `getStoresByUserId(userId)` to the Firestore client utils
- Adds "我的刊登" link to the `NavAuthStatus` dropdown (visible when logged in)
- Post-sell redirect now lands on `/new/my-listings` instead of the public store list

## What's in each listing card

| Field | Notes |
|---|---|
| Cover image | First uploaded image resolved via `getDownloadURL`; placeholder if none |
| Store name | Primary heading |
| Category + Location | `city · district · category` |
| Asking price | Formatted as `NT$ X 萬` |
| Created date | Relative ("X 天前") |
| Status badge | `審核中` (amber) / `刊登中` (green) / `未通過` (red) |
| View link | Only shown when `approved` → links to `/new/store/[id]` |

## Auth behaviour

Unauthenticated users are redirected to `/new/login?redirect=/new/my-listings`.

## Reviewer notes

- `getStoresByUserId` uses `where("user", "==", userId)` + `orderBy("createTime", "desc")`. This requires a **composite Firestore index** on `(user, createTime)`. If the index doesn't exist yet, Firestore will log an error with a direct link to create it.
- Images in Firestore are stored as raw Storage paths. `ListingCard` resolves each cover image to a download URL client-side via `getDownloadURL` — this avoids the `next/image` invalid-src error.

## Test plan

- [ ] Log in and navigate to `/new/my-listings` via the nav dropdown
- [ ] Verify listing cards render with correct status badges
- [ ] Verify cover image loads (or placeholder shows if no images)
- [ ] Submit a new store via `/new/sell` — confirm redirect lands on `/new/my-listings`
- [ ] Verify unauthenticated users are redirected to login
- [ ] Verify empty state shows with "立即免費刊登" CTA when user has no listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)