### PR TITLE
fix & feat: nav fixes + HeroSplit buyer/seller wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Images in Firestore are stored as raw Storage paths (e.g. `mockStore/{storeId}/1
 - Use CSS nesting syntax (`& .child`, `&.modifier`) — all existing modules already do this.
 - CSS variable tokens (`--ink`, `--paper`, `--accent`, `--hand`, `--display`, `--mono`) are defined on the root wrapper div and cascade to all children — reference via `var(--token)`, never redefine per component.
 - The `/new` route defines an extended token set in `app/new/layout.module.css`: `--ink-2`, `--paper-2`, `--paper-3`, `--accent-2`, `--accent-3`, `--muted`, `--note`, `--brand`. Use these when building any page under `app/new/`.
+- Never use `overflow: hidden` on a container that holds `<Dropdown>` or any other absolutely-positioned menu — the menu will be clipped. Apply `border-radius` to the child elements directly instead.
 
 ## Component conventions
 
@@ -94,3 +95,11 @@ Every page under `app/new/` follows this structure:
 
 - Pass `activeLink` matching the **exact label string** from the `navLinks` array in `SiteNav.tsx` — this highlights the current page.
 - The inner wrapper must be `<div className="flex-1">` (or omitted entirely) — **never** wrap sections in a `max-width` constrained frame div. The `Section` component handles its own full-width background colors; a constrained wrapper causes dark/alt sections to render as floating boxes instead of full-width bands.
+
+### Search filter state pattern
+
+URL params are the source of truth for filter state in `/new/store-list`. Two rules:
+
+1. **Navigation into store-list** — always build a `URLSearchParams` object and call `router.push('/new/store-list?...')`. Never write to Jotai atoms cross-page. Supported params: `city`, `category`, `tag`, `amountMin`, `amountMax`.
+
+2. **SearchBar hydration** — `SearchBar.tsx` runs a `useEffect([], [])` on mount that reads `useSearchParams()` and sets `cityAtom`, `tagAtom`, `categoryAtom`, `amountFilterAtom` so the dropdowns reflect the current URL. This must be preserved whenever SearchBar is modified.

--- a/app/new/_components/HeroSplit/BuyerForm.tsx
+++ b/app/new/_components/HeroSplit/BuyerForm.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import Dropdown from "@/components/refactored/Dropdown";
 import { cityItems, amountItems } from "@/components/SearchFilter/DropDowns";
 import { STORE_CATEGORIES } from "@/constant/storeType";
-import { STORE_TAGS } from "@/constant/storeTags";
 import styles from "./HeroSplit.module.css";
 
 const cityOptions = cityItems.map((item) => ({
@@ -14,11 +13,6 @@ const cityOptions = cityItems.map((item) => ({
 }));
 
 const categoryOptions = STORE_CATEGORIES.map((item) => ({
-  label: item.label,
-  value: item.key,
-}));
-
-const tagOptions = STORE_TAGS.map((item) => ({
   label: item.label,
   value: item.key,
 }));
@@ -33,14 +27,12 @@ export default function BuyerForm() {
   const [isPending, startTransition] = useTransition();
   const [city, setCity] = useState("");
   const [category, setCategory] = useState("");
-  const [tag, setTag] = useState("");
   const [amountKey, setAmountKey] = useState("");
 
   function buildParams() {
     const params = new URLSearchParams();
     if (city) params.set("city", city);
     if (category) params.set("category", category);
-    if (tag) params.set("tag", tag);
     const amountItem = amountItems.find((item) => item.key === amountKey);
     if (amountItem) {
       const [min, max] = amountItem.value;
@@ -66,13 +58,6 @@ export default function BuyerForm() {
         value={category}
         onChange={setCategory}
         placeholder="餐飲 · 飲料 · 零售 …"
-      />
-      <Dropdown
-        label="標籤"
-        options={tagOptions}
-        value={tag}
-        onChange={setTag}
-        placeholder="急售 · 熱門 · 精選 …"
       />
       <Dropdown
         label="頂讓金"

--- a/app/new/_components/HeroSplit/BuyerForm.tsx
+++ b/app/new/_components/HeroSplit/BuyerForm.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Dropdown from "@/components/refactored/Dropdown";
+import { cityItems, amountItems } from "@/components/SearchFilter/DropDowns";
+import { STORE_CATEGORIES } from "@/constant/storeType";
+import { STORE_TAGS } from "@/constant/storeTags";
+import styles from "./HeroSplit.module.css";
+
+const cityOptions = cityItems.map((item) => ({
+  label: item.label as string,
+  value: item.key,
+}));
+
+const categoryOptions = STORE_CATEGORIES.map((item) => ({
+  label: item.label,
+  value: item.key,
+}));
+
+const tagOptions = STORE_TAGS.map((item) => ({
+  label: item.label,
+  value: item.key,
+}));
+
+const amountOptions = amountItems.map((item) => ({
+  label: item.label,
+  value: item.key,
+}));
+
+export default function BuyerForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [city, setCity] = useState("");
+  const [category, setCategory] = useState("");
+  const [tag, setTag] = useState("");
+  const [amountKey, setAmountKey] = useState("");
+
+  function buildParams() {
+    const params = new URLSearchParams();
+    if (city) params.set("city", city);
+    if (category) params.set("category", category);
+    if (tag) params.set("tag", tag);
+    const amountItem = amountItems.find((item) => item.key === amountKey);
+    if (amountItem) {
+      const [min, max] = amountItem.value;
+      if (min) params.set("amountMin", String(min));
+      if (max !== Number.POSITIVE_INFINITY)
+        params.set("amountMax", String(max));
+    }
+    return params;
+  }
+
+  return (
+    <div className={styles.form}>
+      <Dropdown
+        label="地區"
+        options={cityOptions}
+        value={city}
+        onChange={setCity}
+        placeholder="選擇縣市"
+      />
+      <Dropdown
+        label="行業"
+        options={categoryOptions}
+        value={category}
+        onChange={setCategory}
+        placeholder="餐飲 · 飲料 · 零售 …"
+      />
+      <Dropdown
+        label="標籤"
+        options={tagOptions}
+        value={tag}
+        onChange={setTag}
+        placeholder="急售 · 熱門 · 精選 …"
+      />
+      <Dropdown
+        label="頂讓金"
+        options={amountOptions}
+        value={amountKey}
+        onChange={setAmountKey}
+        placeholder="不限"
+      />
+      <button
+        type="button"
+        className={styles.btn}
+        onClick={() =>
+          startTransition(() =>
+            router.push(`/new/store-list?${buildParams().toString()}`),
+          )
+        }
+        disabled={isPending}
+      >
+        {isPending ? "搜尋中…" : "瀏覽符合的店 →"}
+      </button>
+    </div>
+  );
+}

--- a/app/new/_components/HeroSplit/HeroSplit.module.css
+++ b/app/new/_components/HeroSplit/HeroSplit.module.css
@@ -45,7 +45,6 @@
   gap: 0;
   border: 2px solid var(--ink);
   border-radius: 6px;
-  overflow: hidden;
   background: #fff;
 }
 .col {
@@ -58,11 +57,13 @@
 }
 .buy {
   background: var(--paper-2);
+  border-radius: 4px 0 0 4px;
 }
 .sell {
   background: var(--ink);
   color: var(--paper);
   border-left: 1.5px solid var(--ink);
+  border-radius: 0 4px 4px 0;
 }
 .sell * {
   color: var(--paper);
@@ -197,8 +198,12 @@
   .split {
     grid-template-columns: 1fr;
   }
+  .buy {
+    border-radius: 4px 4px 0 0;
+  }
   .sell {
     border-left: 0;
     border-top: 1.5px solid var(--ink);
+    border-radius: 0 0 4px 4px;
   }
 }

--- a/app/new/_components/HeroSplit/HeroSplit.module.css
+++ b/app/new/_components/HeroSplit/HeroSplit.module.css
@@ -158,6 +158,41 @@
   color: var(--paper);
 }
 
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: var(--hand);
+  font-size: 16px;
+  counter-reset: steps;
+}
+.steps li {
+  counter-increment: steps;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #cfc8b8;
+}
+.steps li::before {
+  content: counter(steps);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--accent-3);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--accent-3);
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
 .btn {
   font-family: var(--hand);
   font-weight: 700;
@@ -182,6 +217,7 @@
 .btnMus {
   background: var(--accent-3);
   color: var(--ink);
+  margin-top: auto;
 }
 
 .row {

--- a/app/new/_components/HeroSplit/index.tsx
+++ b/app/new/_components/HeroSplit/index.tsx
@@ -1,5 +1,6 @@
 import Pill from "@/components/refactored/Pill";
 import styles from "./HeroSplit.module.css";
+import BuyerForm from "./BuyerForm";
 
 export default function HeroSplit() {
   return (
@@ -25,36 +26,8 @@ export default function HeroSplit() {
             <br />
             接手就開張
           </h2>
-          <p className={styles.lead}>
-            2,481 間真實刊登 · 含設備清單、客群分析、月營業額參考
-          </p>
-          <div className={styles.form}>
-            <div className={styles.field}>
-              <b>地區</b>
-              <span className={styles.fieldCar}>選擇縣市 / 行政區</span>
-            </div>
-            <div className={styles.field}>
-              <b>行業</b>
-              <span className={styles.fieldCar}>餐飲 · 飲料 · 零售 …</span>
-            </div>
-            <div className={styles.formGrid2}>
-              <div className={styles.field}>
-                <b>頂讓金</b>
-                <span className={styles.fieldCar}>不限</span>
-              </div>
-              <div className={styles.field}>
-                <b>坪數</b>
-                <span className={styles.fieldCar}>不限</span>
-              </div>
-            </div>
-            <span className={styles.btn}>瀏覽符合的店 →</span>
-          </div>
-          <div className={styles.row}>
-            <Pill>100 萬以下</Pill>
-            <Pill>含生財設備</Pill>
-            <Pill variant="warm">急售</Pill>
-            <Pill>捷運站旁</Pill>
-          </div>
+          <p className={styles.lead}>真實刊登 · 直接聯絡賣家，不經中間人</p>
+          <BuyerForm />
         </div>
 
         <div className={`${styles.col} ${styles.sell}`}>

--- a/app/new/_components/HeroSplit/index.tsx
+++ b/app/new/_components/HeroSplit/index.tsx
@@ -1,4 +1,3 @@
-import Pill from "@/components/refactored/Pill";
 import styles from "./HeroSplit.module.css";
 import BuyerForm from "./BuyerForm";
 
@@ -38,26 +37,16 @@ export default function HeroSplit() {
             找到接手人
           </h2>
           <p className={styles.lead}>
-            5 分鐘填好就上架 · <b>前 3 個月免費（限早鳥）</b> · 買家直接聯絡你
+            前 3 個月免費刊登（限早鳥）· 買家直接聯絡你，0 抽成
           </p>
-          <div className={styles.form}>
-            <div className={`${styles.field} ${styles.fieldInput}`}>
-              <b>店在</b>
-              <span className={styles.fieldCar}>輸入店面地址 ⌨︎</span>
-            </div>
-            <div className={styles.field}>
-              <b>類型</b>
-              <span className={styles.fieldCar}>選擇行業類別</span>
-            </div>
-            <span className={`${styles.btn} ${styles.btnMus}`}>
-              早鳥免費刊登 →
-            </span>
-          </div>
-          <div className={styles.row}>
-            <Pill variant="outlineLight">早鳥 0 元</Pill>
-            <Pill variant="outlineLight">本月新案 136</Pill>
-            <Pill variant="outlineLight">不抽成</Pill>
-          </div>
+          <ol className={styles.steps}>
+            <li>免費建立帳號</li>
+            <li>5 分鐘填完刊登表</li>
+            <li>上架，買家直接聯絡你</li>
+          </ol>
+          <a href="/new/sell" className={`${styles.btn} ${styles.btnMus}`}>
+            立即免費刊登 →
+          </a>
         </div>
       </div>
     </section>

--- a/app/new/_components/Logo.module.css
+++ b/app/new/_components/Logo.module.css
@@ -2,6 +2,7 @@
   display: inline-flex;
   align-items: flex-start;
   line-height: 1;
+  text-decoration: none;
 }
 
 .text {

--- a/app/new/_components/Logo.tsx
+++ b/app/new/_components/Logo.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import styles from "./Logo.module.css";
 
 export default function Logo({
@@ -10,7 +11,7 @@ export default function Logo({
   light?: boolean;
 }) {
   return (
-    <div className={`${styles.logo} ${light ? styles.light : ""}`}>
+    <Link href="/new" className={`${styles.logo} ${light ? styles.light : ""}`}>
       <div className={styles.text}>
         Bezold
         <small>
@@ -18,6 +19,6 @@ export default function Logo({
           {subtitle}
         </small>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/app/new/_components/SiteNav.tsx
+++ b/app/new/_components/SiteNav.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 
 const navLinks = [
   { label: "我要找店", href: "/new/store-list" },
-  { label: "我要頂出", href: "/new/store-sell" },
+  { label: "我要頂出", href: "/new/sell" },
   { label: "頂讓指南", href: "/new/store-guide" },
   { label: "常見問題", href: "/new/faq" },
 ];

--- a/app/new/store-list/_components/SearchBar.tsx
+++ b/app/new/store-list/_components/SearchBar.tsx
@@ -4,8 +4,8 @@ import styles from "./SearchBar.module.css";
 import Button from "@/components/refactored/Button";
 import Dropdown from "@/components/refactored/Dropdown";
 import { useAtom } from "jotai";
-import { useRouter } from "next/navigation";
-import { useTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useTransition } from "react";
 import {
   cityAtom,
   tagAtom,
@@ -21,11 +21,37 @@ const toOptions = (items: { label: string; key: string }[]) =>
 
 export default function SearchBar() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const [city, setCity] = useAtom(cityAtom);
   const [tag, setTag] = useAtom(tagAtom);
   const [amountFilter, setAmountFilter] = useAtom(amountFilterAtom);
   const [category, setCategory] = useAtom(categoryAtom);
+
+  useEffect(() => {
+    const cityParam = searchParams.get("city");
+    const tagParam = searchParams.get("tag");
+    const categoryParam = searchParams.get("category");
+    const amountMinParam = searchParams.get("amountMin");
+    const amountMaxParam = searchParams.get("amountMax");
+
+    if (cityParam) setCity(cityItems.find((item) => item.key === cityParam));
+    if (tagParam) setTag(STORE_TAGS.find((item) => item.key === tagParam));
+    if (categoryParam)
+      setCategory(STORE_CATEGORIES.find((item) => item.key === categoryParam));
+    if (amountMinParam || amountMaxParam) {
+      const min = amountMinParam ? Number(amountMinParam) : 0;
+      const max = amountMaxParam
+        ? Number(amountMaxParam)
+        : Number.POSITIVE_INFINITY;
+      setAmountFilter(
+        amountItems.find(
+          (item) => item.value[0] === min && item.value[1] === max,
+        ),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSearch = () => {
     const params = new URLSearchParams();

--- a/components/refactored/Pill.module.css
+++ b/components/refactored/Pill.module.css
@@ -8,6 +8,10 @@
   color: var(--ink);
   display: inline-block;
 }
+.clickable {
+  cursor: pointer;
+  user-select: none;
+}
 .solid {
   background: var(--ink);
   color: var(--paper);

--- a/components/refactored/Pill.tsx
+++ b/components/refactored/Pill.tsx
@@ -11,10 +11,19 @@ export type PillVariant =
 export default function Pill({
   variant = "default",
   children,
+  onClick,
 }: {
   variant?: PillVariant;
   children: React.ReactNode;
+  onClick?: () => void;
 }) {
   const variantCls = variant === "default" ? "" : styles[variant];
-  return <span className={`${styles.pill} ${variantCls}`}>{children}</span>;
+  return (
+    <span
+      className={`${styles.pill} ${variantCls} ${onClick ? styles.clickable : ""}`}
+      onClick={onClick}
+    >
+      {children}
+    </span>
+  );
 }


### PR DESCRIPTION
## Summary

- **fix**: `我要頂出` nav tab was pointing to `/new/store-sell` (non-existent) — corrected to `/new/sell`
- **feat**: Bezold logo in SiteNav now links to `/new` home page
- **feat**: HeroSplit buyer col wired to store-list with real Dropdowns (地區 / 行業 / 頂讓金) that build URL params and navigate to `/new/store-list?...`
- **feat**: SearchBar on store-list hydrates its atoms from URL params on mount, so arriving from HeroSplit pre-fills the filter dropdowns
- **feat**: HeroSplit seller col redesigned — fake form inputs replaced with a numbered 3-step flow (免費建立帳號 → 5分鐘填表 → 上架), CTA links to `/new/sell` (auth redirect handles signup)
- **fix**: Dropdown menus were clipped by `overflow: hidden` on `.split` — removed it and applied border-radius to child columns directly
- **chore**: Pill component gains an optional `onClick` prop

## Reviewer notes

- The seller CTA (`立即免費刊登 →`) uses a plain `<a href="/new/sell">` — the sell page already redirects unauthenticated users to `/new/login?redirect=/new/sell`, so no extra logic needed.
- `SearchBar` URL hydration runs only on mount (`[]` dep array) to avoid overwriting user selections on re-render.
- `坪數` filter was dropped from HeroSplit — it has no backing field in Firestore or `getStores()`.

## Test plan

- [ ] Click `我要頂出` in nav → lands on `/new/sell`
- [ ] Click Bezold logo → lands on `/new`
- [ ] Select filters in HeroSplit buyer col, click `瀏覽符合的店 →` → navigates to `/new/store-list?...` with correct params and SearchBar dropdowns pre-filled
- [ ] Click `立即免費刊登 →` (not logged in) → redirects to login with redirect param
- [ ] Open any dropdown in HeroSplit → menu is not clipped by the card border

🤖 Generated with [Claude Code](https://claude.com/claude-code)