### PR TITLE
feat(new): wire live store data into home page sections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Images in Firestore are stored as raw Storage paths (e.g. `mockStore/{storeId}/1
 - CSS variable tokens (`--ink`, `--paper`, `--accent`, `--hand`, `--display`, `--mono`) are defined on the root wrapper div and cascade to all children — reference via `var(--token)`, never redefine per component.
 - The `/new` route defines an extended token set in `app/new/layout.module.css`: `--ink-2`, `--paper-2`, `--paper-3`, `--accent-2`, `--accent-3`, `--muted`, `--note`, `--brand`. Use these when building any page under `app/new/`.
 - Never use `overflow: hidden` on a container that holds `<Dropdown>` or any other absolutely-positioned menu — the menu will be clipped. Apply `border-radius` to the child elements directly instead.
+- When a CSS module class is applied to an `<a>` element, always add `text-decoration: none; color: inherit` to that class — browser link defaults otherwise override the design system styles.
 
 ## Component conventions
 
@@ -75,6 +76,7 @@ Images in Firestore are stored as raw Storage paths (e.g. `mockStore/{storeId}/1
 - **Sub-components** (FaqItem, Step, WhyUsItem, etc.) go at the bottom of the parent file unless reused elsewhere or the file becomes hard to navigate.
 - Use `cn()` from `@/lib/utils` for all conditional class name composition — never string template literals.
 - Ant Design is configured with primary color `#ff4a31` via `ConfigProvider` in the root layout.
+- **Optionally-clickable primitives** — shared components that are sometimes links and sometimes static accept `href?: string` and render as `<a>` when provided, `<div>` otherwise. See `Category.tsx` and the `District` sub-component in `Districts.tsx` for the established pattern.
 
 ### `/new` page shell pattern
 

--- a/app/new/_components/Categories.tsx
+++ b/app/new/_components/Categories.tsx
@@ -3,27 +3,50 @@ import SectionTitle from "@/components/refactored/SectionTitle";
 import Category, {
   type Category as CategoryType,
 } from "@/components/refactored/Category";
+import { STORE_CATEGORY } from "@/types";
 import cn from "classnames";
 
 const categories: CategoryType[] = [
-  { ico: "餐", variant: "a", name: "餐飲", count: "412" },
-  { ico: "咖", variant: "b", name: "咖啡", count: "188" },
-  { ico: "飲", variant: "c", name: "手搖飲", count: "156" },
-  { ico: "火", variant: "default", name: "火鍋燒烤", count: "74" },
-  { ico: "美", variant: "a", name: "美容美髮", count: "96" },
-  { ico: "補", variant: "c", name: "補習教育", count: "41" },
-  { ico: "零", variant: "b", name: "零售", count: "132" },
-  { ico: "他", variant: "default", name: "其他", count: "88" },
+  {
+    ico: "餐",
+    variant: "a",
+    name: "餐飲",
+    href: `/new/store-list?category=${STORE_CATEGORY.RESTAURANT}`,
+  },
+  {
+    ico: "服",
+    variant: "b",
+    name: "服飾",
+    href: `/new/store-list?category=${STORE_CATEGORY.CLOTHING}`,
+  },
+  {
+    ico: "工",
+    variant: "c",
+    name: "工廠",
+    href: `/new/store-list?category=${STORE_CATEGORY.FACTORY}`,
+  },
+  {
+    ico: "百",
+    variant: "default",
+    name: "百貨",
+    href: `/new/store-list?category=${STORE_CATEGORY.DEPARTMENT}`,
+  },
+  {
+    ico: "他",
+    variant: "a",
+    name: "其他",
+    href: `/new/store-list?category=${STORE_CATEGORY.OTHERS}`,
+  },
 ];
 
 export default function Categories() {
   return (
     <Section>
-      <SectionTitle num="05" title="依行業瀏覽" sub="— 從你熟悉的類型開始 —" />
+      <SectionTitle num="06" title="依行業瀏覽" sub="— 從你熟悉的類型開始 —" />
       <div
         className={cn(
           "grid gap-2",
-          "lg:grid-cols-8 md:grid-cols-4 grid-cols-3",
+          "lg:grid-cols-5 md:grid-cols-5 grid-cols-3",
         )}
       >
         {categories.map((category) => (

--- a/app/new/_components/Districts.module.css
+++ b/app/new/_components/Districts.module.css
@@ -1,4 +1,6 @@
 .dist {
+  text-decoration: none;
+  color: inherit;
   border: 1.5px solid var(--ink);
   background: #fff;
   border-radius: 4px;

--- a/app/new/_components/Districts.tsx
+++ b/app/new/_components/Districts.tsx
@@ -4,24 +4,25 @@ import styles from "./Districts.module.css";
 import cn from "classnames";
 
 const districts = [
-  { name: "大安區", en: "DA-AN", count: "124" },
-  { name: "信義區", en: "XINYI", count: "89" },
-  { name: "中山區", en: "ZHONGSHAN", count: "76" },
-  { name: "板橋區", en: "BANQIAO", count: "58" },
-  { name: "三重區", en: "SANCHONG", count: "41" },
-  { name: "新店區", en: "XINDIAN", count: "33" },
-  { name: "桃園市", en: "TAOYUAN", count: "112" },
-  { name: "台中西區", en: "TAICHUNG-W", count: "67" },
+  { name: "臺北市", en: "TAIPEI", count: "289", city: "臺北市" },
+  { name: "新北市", en: "NEW-TAIPEI", count: "132", city: "新北市" },
+  { name: "桃園市", en: "TAOYUAN", count: "112", city: "桃園市" },
+  { name: "臺中市", en: "TAICHUNG", count: "67", city: "臺中市" },
+  { name: "臺南市", en: "TAINAN", count: "54", city: "臺南市" },
+  { name: "高雄市", en: "KAOHSIUNG", count: "48", city: "高雄市" },
+  { name: "新竹市", en: "HSINCHU", count: "31", city: "新竹市" },
+  { name: "基隆市", en: "KEELUNG", count: "24", city: "基隆市" },
 ];
 
 export default function Districts() {
   return (
     <Section variant="alt">
       <SectionTitle
-        num="06"
-        title="熱門商圈"
-        sub="— 點擊看該區所有刊登 —"
-        more="看全部地區 →"
+        num="07"
+        title="熱門城市"
+        sub="— 點擊看該市所有刊登 —"
+        more="看全部城市 →"
+        moreHref="/new/store-list"
       />
       <div className={cn("grid gap-2", "lg:grid-cols-4 grid-cols-2")}>
         {districts.map((district) => (
@@ -32,21 +33,25 @@ export default function Districts() {
   );
 }
 
-export type District = {
+type District = {
   name: string;
   en: string;
   count: string;
+  city: string;
 };
 
 function District({ district }: { district: District }) {
-  const { name, en, count } = district;
+  const { name, en, count, city } = district;
   return (
-    <div key={name} className={styles.dist}>
+    <a
+      href={`/new/store-list?city=${encodeURIComponent(city)}`}
+      className={styles.dist}
+    >
       <div className={styles.left}>
         {name}
         <small>{en}</small>
       </div>
       <div className={styles.count}>{count}</div>
-    </div>
+    </a>
   );
 }

--- a/app/new/_components/FeaturedListings.module.css
+++ b/app/new/_components/FeaturedListings.module.css
@@ -89,12 +89,10 @@
   font-size: 10px;
   color: var(--ink-2);
 }
-.tabs {
-  display: flex;
-  justify-content: center;
-  margin-top: 18px;
-  gap: 12px;
-  flex-wrap: wrap;
+.cardLink {
+  text-decoration: none;
+  color: inherit;
+  display: block;
 }
 
 @media (max-width: 900px) {

--- a/app/new/_components/FeaturedListings.tsx
+++ b/app/new/_components/FeaturedListings.tsx
@@ -5,7 +5,23 @@ import StoreCard from "@/components/refactored/StoreCard";
 import { type Store, STORE_STATUS } from "@/types";
 import { storeToCard } from "@/utils/store";
 
-export default function FeaturedListings({ stores }: { stores: Store[] }) {
+type Props = {
+  stores: Store[];
+  num?: string;
+  title?: string;
+  sub?: string;
+  more?: string;
+  moreHref?: string;
+};
+
+export default function FeaturedListings({
+  stores,
+  num = "04",
+  title = "編輯精選",
+  sub = "— 編輯挑選，含設備、地段佳 —",
+  more = "看全部 →",
+  moreHref,
+}: Props) {
   const approvedStores = stores.filter(
     (store) => store.status === STORE_STATUS.APPROVED,
   );
@@ -15,10 +31,11 @@ export default function FeaturedListings({ stores }: { stores: Store[] }) {
   return (
     <Section variant="alt">
       <SectionTitle
-        num="04"
-        title="本週精選 / 急售"
-        sub="— 編輯挑選，含設備、地段佳 —"
-        more="看全部 →"
+        num={num}
+        title={title}
+        sub={sub}
+        more={more}
+        moreHref={moreHref}
       />
       <div className={styles.listings}>
         {approvedStores.map((store) => (

--- a/app/new/_components/FeaturedListings.tsx
+++ b/app/new/_components/FeaturedListings.tsx
@@ -1,80 +1,35 @@
 import Section from "./Section";
 import SectionTitle from "@/components/refactored/SectionTitle";
-import Pill from "@/components/refactored/Pill";
 import styles from "./FeaturedListings.module.css";
-import StoreCard, {
-  type StoreCard as StoreCardType,
-} from "@/components/refactored/StoreCard";
+import StoreCard from "@/components/refactored/StoreCard";
+import { type Store, STORE_STATUS } from "@/types";
+import { storeToCard } from "@/utils/store";
 
-const featured: StoreCardType[] = [
-  {
-    tags: [
-      { label: "急售", variant: "warm" },
-      { label: "餐飲", variant: "default" },
-      { label: "含設備", variant: "mus" },
-    ],
-    title: "大安溫州街 · 老字號麵店",
-    meta: [
-      ["坪數", "12 坪"],
-      ["月租", "4.8 萬"],
-      ["已開", "8 年"],
-      ["客群", "學生 / 鄰里"],
-    ],
-    price: "NT$ 65 萬",
-    rent: "月租 / 押金已議",
-  },
-  {
-    tags: [
-      { label: "含證照", variant: "sage" },
-      { label: "飲料", variant: "default" },
-    ],
-    title: "中山赤峰 · 手搖飲品牌店",
-    meta: [
-      ["坪數", "8 坪"],
-      ["月租", "3.2 萬"],
-      ["已開", "3 年"],
-      ["設備", "全新整套"],
-    ],
-    price: "NT$ 45 萬",
-    rent: "押 2 / 含轉約",
-  },
-  {
-    tags: [
-      { label: "議價", variant: "mus" },
-      { label: "美容", variant: "default" },
-    ],
-    title: "板橋府中 · 美髮沙龍",
-    meta: [
-      ["坪數", "22 坪"],
-      ["月租", "6 萬"],
-      ["椅位", "4 椅"],
-      ["客群", "預約穩定"],
-    ],
-    price: "NT$ 120 萬",
-    rent: "含現有客戶",
-  },
-];
+export default function FeaturedListings({ stores }: { stores: Store[] }) {
+  const approvedStores = stores.filter(
+    (store) => store.status === STORE_STATUS.APPROVED,
+  );
 
-export default function FeaturedListings() {
+  if (approvedStores.length === 0) return null;
+
   return (
     <Section variant="alt">
       <SectionTitle
         num="04"
         title="本週精選 / 急售"
         sub="— 編輯挑選，含設備、地段佳 —"
-        more="看全部 412 間 →"
+        more="看全部 →"
       />
       <div className={styles.listings}>
-        {featured.map((card, i) => (
-          <StoreCard key={i} card={card} />
+        {approvedStores.map((store) => (
+          <a
+            key={store.id}
+            href={`/new/store/${store.id}`}
+            className={styles.cardLink}
+          >
+            <StoreCard card={storeToCard(store)} />
+          </a>
         ))}
-      </div>
-      <div className={styles.tabs}>
-        <Pill variant="solid">最新</Pill>
-        <Pill>急售</Pill>
-        <Pill>熱門收藏</Pill>
-        <Pill>編輯精選</Pill>
-        <Pill>100 萬以下</Pill>
       </div>
     </Section>
   );

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -13,7 +13,10 @@ import Stories from "./_components/Stories";
 import SellerCta from "./_components/SellerCta";
 import Faq from "./_components/Faq";
 import SiteFooter from "./_components/SiteFooter";
-import { getHighlightedStores } from "@/firebase/serverUtils/store";
+import {
+  getHighlightedStores,
+  getEmergencyStores,
+} from "@/firebase/serverUtils/store";
 
 export const metadata: Metadata = {
   title: "頂讓.tw — 找一間準備好的店",
@@ -22,7 +25,10 @@ export const metadata: Metadata = {
 };
 
 export default async function NewHomePage() {
-  const highlightedStores = await getHighlightedStores();
+  const [highlightedStores, emergencyStores] = await Promise.all([
+    getHighlightedStores(),
+    getEmergencyStores(),
+  ]);
 
   return (
     <>
@@ -31,7 +37,18 @@ export default async function NewHomePage() {
       <div className={styles.frame}>
         <HeroSplit />
         <TrustBar />
-        <FeaturedListings stores={highlightedStores} />
+        <FeaturedListings
+          stores={highlightedStores}
+          moreHref="/new/store-list?tag=RECOMMENDED"
+        />
+        <FeaturedListings
+          stores={emergencyStores}
+          num="05"
+          title="急售特區"
+          sub="— 限時出售，把握機會 —"
+          more="看全部急售 →"
+          moreHref="/new/store-list?tag=EMERGENCY"
+        />
         <Categories />
         <Districts />
         <HowItWorks />

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -13,6 +13,7 @@ import Stories from "./_components/Stories";
 import SellerCta from "./_components/SellerCta";
 import Faq from "./_components/Faq";
 import SiteFooter from "./_components/SiteFooter";
+import { getHighlightedStores } from "@/firebase/serverUtils/store";
 
 export const metadata: Metadata = {
   title: "頂讓.tw — 找一間準備好的店",
@@ -20,7 +21,9 @@ export const metadata: Metadata = {
     "全台店面頂讓平台。買家直接接手已有客群、設備、營運的店面；賣家把心血交給合適的人。早鳥前 3 個月免費刊登，永久不抽成。",
 };
 
-export default function NewHomePage() {
+export default async function NewHomePage() {
+  const highlightedStores = await getHighlightedStores();
+
   return (
     <>
       <LaunchBanner />
@@ -28,7 +31,7 @@ export default function NewHomePage() {
       <div className={styles.frame}>
         <HeroSplit />
         <TrustBar />
-        <FeaturedListings />
+        <FeaturedListings stores={highlightedStores} />
         <Categories />
         <Districts />
         <HowItWorks />

--- a/app/new/store-list/_components/ResultsArea.tsx
+++ b/app/new/store-list/_components/ResultsArea.tsx
@@ -8,64 +8,14 @@ import StoreCard, {
 import Dropdown, {
   type DropdownOption,
 } from "@/components/refactored/Dropdown";
-import { type PillVariant } from "@/components/refactored/Pill";
 import { type Store, STORE_STATUS } from "@/types";
-import { STORE_CATEGORIES } from "@/constant/storeType";
-import {
-  TAG_DISPLAY,
-  RIBBON_DISPLAY,
-  RIBBON_PRIORITY,
-} from "@/constant/storeDisplay";
+import { storeToCard } from "@/utils/store";
 
 const sortOptions: DropdownOption[] = [
   { label: "頂讓金：低 → 高", value: "price-asc" },
   { label: "頂讓金：高 → 低", value: "price-desc" },
   { label: "最新上架", value: "newest" },
 ];
-
-function storeToCard(store: Store): StoreCardType {
-  const tags = store.tags ?? [];
-
-  const ribbonTag = RIBBON_PRIORITY.find((tag) => tags.includes(tag));
-  const ribbon = ribbonTag ? RIBBON_DISPLAY[ribbonTag] : undefined;
-
-  const categoryEntry = STORE_CATEGORIES.find(
-    (cat) => cat.key === store.category,
-  );
-  const categoryLabel = categoryEntry?.label ?? store.category;
-
-  const tagPills = [
-    ...tags.map(
-      (tag) =>
-        TAG_DISPLAY[tag] ?? { label: tag, variant: "default" as PillVariant },
-    ),
-    ...(categoryLabel
-      ? [{ label: categoryLabel, variant: "default" as PillVariant }]
-      : []),
-  ];
-
-  const location =
-    store.location ||
-    [store.city, store.district].filter(Boolean).join(" · ") ||
-    undefined;
-
-  const meta: [string, string][] = [
-    ...(categoryLabel ? [["行業", categoryLabel] as [string, string]] : []),
-    ...(store.city ? [["城市", store.city] as [string, string]] : []),
-  ];
-
-  const price = `NT$ ${Math.round(store.price / 10000)} 萬`;
-
-  return {
-    ribbon,
-    tags: tagPills,
-    title: store.storeName,
-    location,
-    meta,
-    price,
-    rent: store.description?.slice(0, 20) ?? "-",
-  };
-}
 
 function sortStores(stores: Store[], sort: string): Store[] {
   const sorted = [...stores];

--- a/components/refactored/Category.module.css
+++ b/components/refactored/Category.module.css
@@ -1,4 +1,6 @@
 .category {
+  text-decoration: none;
+  color: inherit;
   border: 1.5px solid var(--ink);
   background: #fff;
   border-radius: 4px;

--- a/components/refactored/Category.tsx
+++ b/components/refactored/Category.tsx
@@ -6,8 +6,10 @@ export type Category = {
   ico: string;
   variant: CategoryVariant;
   name: string;
-  count: string;
+  count?: string;
+  href?: string;
 };
+
 const variantClass: Record<CategoryVariant, string> = {
   a: styles.icoA,
   b: styles.icoB,
@@ -16,12 +18,22 @@ const variantClass: Record<CategoryVariant, string> = {
 };
 
 export default function Category({ category }: { category: Category }) {
-  const { ico, variant, name, count } = category;
-  return (
-    <div key={name} className={styles.category}>
+  const { ico, variant, name, count, href } = category;
+  const inner = (
+    <>
       <div className={`${styles.ico} ${variantClass[variant]}`}>{ico}</div>
       <b>{name}</b>
-      <span>{count}</span>
-    </div>
+      {count && <span>{count}</span>}
+    </>
   );
+
+  if (href) {
+    return (
+      <a href={href} className={styles.category}>
+        {inner}
+      </a>
+    );
+  }
+
+  return <div className={styles.category}>{inner}</div>;
 }

--- a/components/refactored/SectionTitle.tsx
+++ b/components/refactored/SectionTitle.tsx
@@ -6,12 +6,14 @@ export default function SectionTitle({
   title,
   sub,
   more,
+  moreHref,
   dark = false,
 }: {
   num: string;
   title: string;
   sub?: string;
   more?: string;
+  moreHref?: string;
   dark?: boolean;
 }) {
   return (
@@ -23,7 +25,11 @@ export default function SectionTitle({
           <span className={cn(styles.sub, dark && styles.subDark)}>{sub}</span>
         )}
       </div>
-      {more && <a className={styles.more}>{more}</a>}
+      {more && (
+        <a className={styles.more} href={moreHref}>
+          {more}
+        </a>
+      )}
     </div>
   );
 }

--- a/firebase/serverUtils/store.ts
+++ b/firebase/serverUtils/store.ts
@@ -141,4 +141,36 @@ export const getHighlightedStores = async () => {
   return stores;
 };
 
+export const getEmergencyStores = async () => {
+  const storesRef = db.collection(COLLECTION);
+
+  const snapshot = await storesRef
+    .where("tags", "array-contains", STORE_TAG.EMERGENCY)
+    .orderBy("updateTime", "desc")
+    .limit(8)
+    .get();
+
+  const stores: Store[] = [];
+  snapshot.forEach((doc) => {
+    const storeData = doc.data();
+    const store = {
+      id: doc.id,
+      ...storeData,
+      createTime: storeData.createTime.toDate(),
+      updateTime: storeData.updateTime.toDate(),
+    } as Store;
+    stores.push(store);
+  });
+
+  for (let storeData of stores) {
+    const hasImage = storeData?.images?.length > 0;
+    let images: string[] = [];
+    if (hasImage) {
+      images = await getImagesByPath(storeData.images);
+      storeData.images = images;
+    }
+  }
+  return stores;
+};
+
 // TODO: create store

--- a/utils/store.ts
+++ b/utils/store.ts
@@ -1,3 +1,57 @@
+import { type PillVariant } from "@/components/refactored/Pill";
+import { type StoreCard } from "@/components/refactored/StoreCard";
+import { type Store } from "@/types";
+import { STORE_CATEGORIES } from "@/constant/storeType";
+import {
+  TAG_DISPLAY,
+  RIBBON_DISPLAY,
+  RIBBON_PRIORITY,
+} from "@/constant/storeDisplay";
+
+export function storeToCard(store: Store): StoreCard {
+  const tags = store.tags ?? [];
+
+  const ribbonTag = RIBBON_PRIORITY.find((tag) => tags.includes(tag));
+  const ribbon = ribbonTag ? RIBBON_DISPLAY[ribbonTag] : undefined;
+
+  const categoryEntry = STORE_CATEGORIES.find(
+    (cat) => cat.key === store.category,
+  );
+  const categoryLabel = categoryEntry?.label ?? store.category;
+
+  const tagPills = [
+    ...tags.map(
+      (tag) =>
+        TAG_DISPLAY[tag] ?? { label: tag, variant: "default" as PillVariant },
+    ),
+    ...(categoryLabel
+      ? [{ label: categoryLabel, variant: "default" as PillVariant }]
+      : []),
+  ];
+
+  const location =
+    store.location ||
+    [store.city, store.district].filter(Boolean).join(" · ") ||
+    undefined;
+
+  const meta: [string, string][] = [
+    ...(categoryLabel ? [["行業", categoryLabel] as [string, string]] : []),
+    ...(store.city ? [["城市", store.city] as [string, string]] : []),
+  ];
+
+  const price = `NT$ ${Math.round(store.price / 10000)} 萬`;
+
+  return {
+    ribbon,
+    tags: tagPills,
+    title: store.storeName,
+    location,
+    meta,
+    price,
+    rent: store.description?.slice(0, 20) ?? "-",
+  };
+}
+
 export const genDefaultStore = () => {
   return {
     storeName: "",


### PR DESCRIPTION
## Summary

- **FeaturedListings**: Replace hardcoded mock cards with live Firestore data. Home page is now an async server component that fetches `RECOMMENDED`-tagged stores (`getHighlightedStores`) and `EMERGENCY`-tagged stores (`getEmergencyStores`) in parallel. Both sections hide cleanly when no approved stores exist.
- **storeToCard**: Extracted the store→card display transformer (previously duplicated in `ResultsArea`) into `utils/store.ts` so both `FeaturedListings` and `ResultsArea` share one implementation.
- **More links**: `SectionTitle` gains an optional `moreHref` prop. Each featured section's "看全部 →" link navigates to store-list with the correct `?tag=` filter pre-applied (`RECOMMENDED` / `EMERGENCY`).
- **Categories**: Replaced 8 fake subcategories with the 5 real `STORE_CATEGORY` values. `Category` component renders as `<a>` when an `href` is passed; each card links to `/new/store-list?category=<KEY>`.
- **Districts → Cities**: Section renamed to 熱門城市 and updated to show 8 major Taiwan cities instead of district-level entries. Each card links to `/new/store-list?city=<city>`. `District` component renders as `<a>` with browser link defaults reset in CSS.

## Reviewer notes

- The `FeaturedListings` sections will be hidden on dev/mock environments — no stores have `RECOMMENDED` or `EMERGENCY` tags in mock Firestore. They will render in prod once tagged stores exist.
- District-level filtering (`?district=`) remains commented out in `getStores()` — city is the finest granularity currently supported.
- All store counts in Categories and Cities sections are still placeholder numbers; wiring live counts would require per-bucket Firestore aggregation queries.

## Test plan

- [ ] Visit `/new` — FeaturedListings sections appear when approved+tagged stores exist in Firestore
- [ ] Click a category card → lands on store-list with correct `category` filter applied
- [ ] Click a city card → lands on store-list with correct `city` filter applied
- [ ] Click "看全部 →" on a featured section → lands on store-list with correct `tag` filter applied
- [ ] Click "看全部城市 →" → lands on store-list with no filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)