### PR TITLE
feat(social + hero): social media links, SocialBar section, hero entrance animations

### DIFF
--- a/app/(new)/_components/HeroSplit/HeroSplit.module.css
+++ b/app/(new)/_components/HeroSplit/HeroSplit.module.css
@@ -10,6 +10,8 @@
   color: var(--accent);
   margin-bottom: 10px;
   text-align: center;
+
+  animation: fadeInDown 0.4s ease-out both;
 }
 .title {
   font-family: var(--display);
@@ -33,6 +35,8 @@
   margin: 0 auto 24px;
   max-width: 560px;
   line-height: 1.5;
+
+  animation: fadeInUp 0.5s ease-out 0.4s both;
 }
 .subAccent {
   color: var(--accent);
@@ -225,6 +229,51 @@
   gap: 8px;
   flex-wrap: wrap;
   margin-top: 4px;
+}
+
+.titleLine {
+  display: block;
+}
+.titleLineInner {
+  display: block;
+
+  animation: heroLineIn 0.55s cubic-bezier(0.16, 1, 0.3, 1) 0.05s both;
+}
+.titleLineInner2 {
+  display: block;
+
+  animation: heroLineIn 0.55s cubic-bezier(0.16, 1, 0.3, 1) 0.18s both;
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes heroLineIn {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (max-width: 640px) {

--- a/app/(new)/_components/HeroSplit/index.tsx
+++ b/app/(new)/_components/HeroSplit/index.tsx
@@ -6,9 +6,14 @@ export default function HeroSplit() {
     <section className={styles.hero}>
       <div className={styles.kicker}>— 全台店面頂讓平台 · 真實刊登 —</div>
       <h1 className={styles.title}>
-        找一間<em>準備好</em>的店
-        <br />
-        開門就營業
+        <span className={styles.titleLine}>
+          <span className={styles.titleLineInner}>
+            找一間<em>準備好</em>的店
+          </span>
+        </span>
+        <span className={styles.titleLine}>
+          <span className={styles.titleLineInner2}>開門就營業</span>
+        </span>
       </h1>
       <p className={styles.sub}>
         買家直接接手已有客群、設備、營運的店面 · 賣家把心血交給合適的人。

--- a/app/(new)/_components/SiteFooter.module.css
+++ b/app/(new)/_components/SiteFooter.module.css
@@ -60,6 +60,20 @@
   border-radius: 4px;
   object-fit: cover;
 }
+.socials {
+  display: flex;
+  gap: 10px;
+  margin-top: 14px;
+}
+.socialLink {
+  color: #999083;
+  font-size: 18px;
+  text-decoration: none;
+
+  &:hover {
+    color: var(--paper);
+  }
+}
 .legal {
   grid-column: 1 / -1;
   border-top: 1.5px dashed var(--paper);

--- a/app/(new)/_components/SiteFooter.tsx
+++ b/app/(new)/_components/SiteFooter.tsx
@@ -4,6 +4,7 @@ import {
   YoutubeFilled,
   FacebookFilled,
   LinkedinFilled,
+  TeamOutlined,
 } from "@ant-design/icons";
 import ThreadsIcon from "@/components/icon/ThreadsIcon";
 import { SOCIAL_LINKS } from "@/constant/socials";
@@ -72,6 +73,15 @@ export default function SiteFooter() {
             aria-label="Facebook"
           >
             <FacebookFilled />
+          </a>
+          <a
+            className={styles.socialLink}
+            href={SOCIAL_LINKS.facebookGroup}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook 社團"
+          >
+            <TeamOutlined />
           </a>
           <a
             className={styles.socialLink}

--- a/app/(new)/_components/SiteFooter.tsx
+++ b/app/(new)/_components/SiteFooter.tsx
@@ -1,4 +1,11 @@
 import Image from "next/image";
+import {
+  InstagramFilled,
+  YoutubeFilled,
+  FacebookFilled,
+  LinkedinFilled,
+} from "@ant-design/icons";
+import ThreadsIcon from "@/components/icon/ThreadsIcon";
 import Logo from "./Logo";
 import styles from "./SiteFooter.module.css";
 
@@ -27,6 +34,53 @@ export default function SiteFooter() {
             <br />
             09:00 – 21:00
           </div>
+        </div>
+        <div className={styles.socials}>
+          <a
+            className={styles.socialLink}
+            href="https://www.instagram.com/bezold.tw?igsh=enVjMDUwZWh3dnJy&utm_source=qr"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <InstagramFilled />
+          </a>
+          <a
+            className={styles.socialLink}
+            href="https://www.youtube.com/@Bezold-v4u"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="YouTube"
+          >
+            <YoutubeFilled />
+          </a>
+          <a
+            className={styles.socialLink}
+            href="https://www.threads.com/@bezold.tw?igshid=NTc4MTIwNjQ2YQ=="
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Threads"
+          >
+            <ThreadsIcon />
+          </a>
+          <a
+            className={styles.socialLink}
+            href="https://www.facebook.com/share/19BX272yzL/?mibextid=wwXIfr"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <FacebookFilled />
+          </a>
+          <a
+            className={styles.socialLink}
+            href="https://www.linkedin.com/in/bezold-tw-98390936b"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="LinkedIn"
+          >
+            <LinkedinFilled />
+          </a>
         </div>
       </div>
       <div>

--- a/app/(new)/_components/SiteFooter.tsx
+++ b/app/(new)/_components/SiteFooter.tsx
@@ -6,6 +6,7 @@ import {
   LinkedinFilled,
 } from "@ant-design/icons";
 import ThreadsIcon from "@/components/icon/ThreadsIcon";
+import { SOCIAL_LINKS } from "@/constant/socials";
 import Logo from "./Logo";
 import styles from "./SiteFooter.module.css";
 
@@ -38,7 +39,7 @@ export default function SiteFooter() {
         <div className={styles.socials}>
           <a
             className={styles.socialLink}
-            href="https://www.instagram.com/bezold.tw?igsh=enVjMDUwZWh3dnJy&utm_source=qr"
+            href={SOCIAL_LINKS.instagram}
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Instagram"
@@ -47,7 +48,7 @@ export default function SiteFooter() {
           </a>
           <a
             className={styles.socialLink}
-            href="https://www.youtube.com/@Bezold-v4u"
+            href={SOCIAL_LINKS.youtube}
             target="_blank"
             rel="noopener noreferrer"
             aria-label="YouTube"
@@ -56,7 +57,7 @@ export default function SiteFooter() {
           </a>
           <a
             className={styles.socialLink}
-            href="https://www.threads.com/@bezold.tw?igshid=NTc4MTIwNjQ2YQ=="
+            href={SOCIAL_LINKS.threads}
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Threads"
@@ -65,7 +66,7 @@ export default function SiteFooter() {
           </a>
           <a
             className={styles.socialLink}
-            href="https://www.facebook.com/share/19BX272yzL/?mibextid=wwXIfr"
+            href={SOCIAL_LINKS.facebook}
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Facebook"
@@ -74,7 +75,7 @@ export default function SiteFooter() {
           </a>
           <a
             className={styles.socialLink}
-            href="https://www.linkedin.com/in/bezold-tw-98390936b"
+            href={SOCIAL_LINKS.linkedin}
             target="_blank"
             rel="noopener noreferrer"
             aria-label="LinkedIn"

--- a/app/(new)/_components/SocialBar.module.css
+++ b/app/(new)/_components/SocialBar.module.css
@@ -1,0 +1,62 @@
+.wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.copy h4 {
+  font-family: var(--display);
+  font-size: 32px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  line-height: 1;
+}
+.copy p {
+  font-family: var(--hand);
+  font-size: 13px;
+  color: var(--ink-2);
+  margin: 0;
+}
+.icons {
+  display: flex;
+  gap: 8px;
+}
+.link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 14px 0;
+  width: 88px;
+  border: 1.5px solid var(--ink);
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 10px;
+  transition:
+    background 0.15s,
+    color 0.15s;
+
+  & :global(.anticon) {
+    font-size: 24px;
+  }
+  & .iconWrap {
+    display: inline-flex;
+  }
+
+  &:hover {
+    background: var(--ink);
+    color: var(--paper);
+  }
+}
+
+@media (max-width: 900px) {
+  .wrap {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .icons {
+    flex-wrap: wrap;
+  }
+}

--- a/app/(new)/_components/SocialBar.tsx
+++ b/app/(new)/_components/SocialBar.tsx
@@ -6,6 +6,7 @@ import {
   YoutubeFilled,
   FacebookFilled,
   LinkedinFilled,
+  TeamOutlined,
 } from "@ant-design/icons";
 import ThreadsIcon from "@/components/icon/ThreadsIcon";
 import { SOCIAL_LINKS } from "@/constant/socials";
@@ -50,6 +51,11 @@ const SOCIALS = [
   { href: SOCIAL_LINKS.youtube, label: "YouTube", icon: <YoutubeFilled /> },
   { href: SOCIAL_LINKS.threads, label: "Threads", icon: <ThreadsIcon /> },
   { href: SOCIAL_LINKS.facebook, label: "Facebook", icon: <FacebookFilled /> },
+  {
+    href: SOCIAL_LINKS.facebookGroup,
+    label: "FB 社團",
+    icon: <TeamOutlined />,
+  },
   { href: SOCIAL_LINKS.linkedin, label: "LinkedIn", icon: <LinkedinFilled /> },
 ];
 

--- a/app/(new)/_components/SocialBar.tsx
+++ b/app/(new)/_components/SocialBar.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { motion } from "motion/react";
+import {
+  InstagramFilled,
+  YoutubeFilled,
+  FacebookFilled,
+  LinkedinFilled,
+} from "@ant-design/icons";
+import ThreadsIcon from "@/components/icon/ThreadsIcon";
+import Section from "./Section";
+import styles from "./SocialBar.module.css";
+
+const containerVariants = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.09, delayChildren: 0.05 },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { type: "spring", stiffness: 280, damping: 22 },
+  },
+  hover: {
+    y: -8,
+    transition: { type: "spring", stiffness: 400, damping: 15 },
+  },
+};
+
+const iconVariants = {
+  visible: {},
+  hover: {
+    scale: 1.3,
+    rotate: -10,
+    transition: { type: "spring", stiffness: 500, damping: 12 },
+  },
+};
+
+const SOCIALS = [
+  {
+    href: "https://www.instagram.com/bezold.tw?igsh=enVjMDUwZWh3dnJy&utm_source=qr",
+    label: "Instagram",
+    icon: <InstagramFilled />,
+  },
+  {
+    href: "https://www.youtube.com/@Bezold-v4u",
+    label: "YouTube",
+    icon: <YoutubeFilled />,
+  },
+  {
+    href: "https://www.threads.com/@bezold.tw?igshid=NTc4MTIwNjQ2YQ==",
+    label: "Threads",
+    icon: <ThreadsIcon />,
+  },
+  {
+    href: "https://www.facebook.com/share/19BX272yzL/?mibextid=wwXIfr",
+    label: "Facebook",
+    icon: <FacebookFilled />,
+  },
+  {
+    href: "https://www.linkedin.com/in/bezold-tw-98390936b",
+    label: "LinkedIn",
+    icon: <LinkedinFilled />,
+  },
+];
+
+export default function SocialBar() {
+  return (
+    <Section>
+      <div className={styles.wrap}>
+        <div className={styles.copy}>
+          <h4>追蹤我們</h4>
+          <p>第一手店面資訊 · 創業知識 · 最新消息</p>
+        </div>
+        <motion.div
+          className={styles.icons}
+          variants={containerVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-60px" }}
+        >
+          {SOCIALS.map(({ href, label, icon }) => (
+            <motion.a
+              key={label}
+              className={styles.link}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={label}
+              variants={itemVariants}
+              whileHover="hover"
+            >
+              <motion.span className={styles.iconWrap} variants={iconVariants}>
+                {icon}
+              </motion.span>
+              <span>{label}</span>
+            </motion.a>
+          ))}
+        </motion.div>
+      </div>
+    </Section>
+  );
+}

--- a/app/(new)/_components/SocialBar.tsx
+++ b/app/(new)/_components/SocialBar.tsx
@@ -8,6 +8,7 @@ import {
   LinkedinFilled,
 } from "@ant-design/icons";
 import ThreadsIcon from "@/components/icon/ThreadsIcon";
+import { SOCIAL_LINKS } from "@/constant/socials";
 import Section from "./Section";
 import styles from "./SocialBar.module.css";
 
@@ -42,30 +43,14 @@ const iconVariants = {
 
 const SOCIALS = [
   {
-    href: "https://www.instagram.com/bezold.tw?igsh=enVjMDUwZWh3dnJy&utm_source=qr",
+    href: SOCIAL_LINKS.instagram,
     label: "Instagram",
     icon: <InstagramFilled />,
   },
-  {
-    href: "https://www.youtube.com/@Bezold-v4u",
-    label: "YouTube",
-    icon: <YoutubeFilled />,
-  },
-  {
-    href: "https://www.threads.com/@bezold.tw?igshid=NTc4MTIwNjQ2YQ==",
-    label: "Threads",
-    icon: <ThreadsIcon />,
-  },
-  {
-    href: "https://www.facebook.com/share/19BX272yzL/?mibextid=wwXIfr",
-    label: "Facebook",
-    icon: <FacebookFilled />,
-  },
-  {
-    href: "https://www.linkedin.com/in/bezold-tw-98390936b",
-    label: "LinkedIn",
-    icon: <LinkedinFilled />,
-  },
+  { href: SOCIAL_LINKS.youtube, label: "YouTube", icon: <YoutubeFilled /> },
+  { href: SOCIAL_LINKS.threads, label: "Threads", icon: <ThreadsIcon /> },
+  { href: SOCIAL_LINKS.facebook, label: "Facebook", icon: <FacebookFilled /> },
+  { href: SOCIAL_LINKS.linkedin, label: "LinkedIn", icon: <LinkedinFilled /> },
 ];
 
 export default function SocialBar() {

--- a/app/(new)/page.tsx
+++ b/app/(new)/page.tsx
@@ -12,6 +12,7 @@ import HowItWorks from "./_components/HowItWorks";
 import WhyUs from "./_components/WhyUs";
 import Stories from "./_components/Stories";
 import SellerCta from "./_components/SellerCta";
+import SocialBar from "./_components/SocialBar";
 import Faq from "./_components/Faq";
 import SiteFooter from "./_components/SiteFooter";
 import {
@@ -59,6 +60,7 @@ export default async function NewHomePage() {
         <WhyUs />
         {/* <Stories /> */}
         <SellerCta />
+        <SocialBar />
         <Faq />
       </div>
       <SiteFooter />

--- a/constant/socials.ts
+++ b/constant/socials.ts
@@ -1,0 +1,8 @@
+export const SOCIAL_LINKS = {
+  instagram:
+    "https://www.instagram.com/bezold.tw?igsh=enVjMDUwZWh3dnJy&utm_source=qr",
+  youtube: "https://www.youtube.com/@Bezold-v4u",
+  threads: "https://www.threads.com/@bezold.tw?igshid=NTc4MTIwNjQ2YQ==",
+  facebook: "https://www.facebook.com/share/19BX272yzL/?mibextid=wwXIfr",
+  linkedin: "https://www.linkedin.com/in/bezold-tw-98390936b",
+} as const;

--- a/constant/socials.ts
+++ b/constant/socials.ts
@@ -1,8 +1,8 @@
 export const SOCIAL_LINKS = {
-  instagram:
-    "https://www.instagram.com/bezold.tw?igsh=enVjMDUwZWh3dnJy&utm_source=qr",
-  youtube: "https://www.youtube.com/@Bezold-v4u",
-  threads: "https://www.threads.com/@bezold.tw?igshid=NTc4MTIwNjQ2YQ==",
-  facebook: "https://www.facebook.com/share/19BX272yzL/?mibextid=wwXIfr",
-  linkedin: "https://www.linkedin.com/in/bezold-tw-98390936b",
+  instagram: "https://www.instagram.com/bezold.tw",
+  youtube: "https://youtube.com/@bezold-v4u",
+  threads: "https://www.threads.com/@bezold.tw",
+  facebook: "https://www.facebook.com/share/1EQcFmcnzs/?mibextid=wwXIfr",
+  facebookGroup: "https://www.facebook.com/groups/9352613548130337",
+  linkedin: "https://www.linkedin.com/company/bezold-tw/",
 } as const;


### PR DESCRIPTION
## Summary

- **Social media links in footer** — Added IG, YouTube, Threads, Facebook, FB 社團 (TeamOutlined), and LinkedIn icons to the `SiteFooter` brand column. All URLs extracted to a single `constant/socials.ts` source of truth so both the footer and SocialBar stay in sync.
- **SocialBar home section** — New `SocialBar` component placed between `SellerCta` and `Faq`. Uses `motion/react` for stagger entrance (scroll-triggered, plays once), hover lift on each box, and icon scale+rotate on hover.
- **Hero title entrance animation** — Pure CSS keyframe animations on the hero: kicker fades down, title line 1 slides up (0.05s delay), title line 2 slides up (0.18s delay), subtitle fades up (0.4s delay). No JS involved.

## Reviewer notes

- `constant/socials.ts` is the single place to update any social URL going forward.
- `SocialBar` is a client component (`"use client"`) due to Motion.js usage; the rest of the page stays server-rendered.
- The hero animation uses only CSS (`@keyframes`) — no new dependencies introduced.
- Facebook page (`FacebookFilled`) and Facebook group (`TeamOutlined`) use different icons to distinguish them visually.

## Test plan

- [ ] Visit home page — confirm hero kicker/title/subtitle animate in on load
- [ ] Scroll to SocialBar — confirm boxes stagger in, hover lifts box and bounces icon
- [ ] Scroll to footer — confirm all 6 social icons render and link correctly
- [ ] Verify all social URLs open the correct profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)