### PR TITLE
feat(seo): fix technical SEO fundamentals (lang, sitemap, robots, metadata, structured data)

### DIFF
--- a/app/(new)/_components/JsonLd.tsx
+++ b/app/(new)/_components/JsonLd.tsx
@@ -1,0 +1,12 @@
+interface JsonLdProps {
+  data: Record<string, unknown>;
+}
+
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/app/(new)/page.tsx
+++ b/app/(new)/page.tsx
@@ -15,10 +15,12 @@ import SellerCta from "./_components/SellerCta";
 import SocialBar from "./_components/SocialBar";
 import Faq from "./_components/Faq";
 import SiteFooter from "./_components/SiteFooter";
+import JsonLd from "./_components/JsonLd";
 import {
   getHighlightedStores,
   getEmergencyStores,
 } from "@/firebase/serverUtils/store";
+import { SOCIAL_LINKS } from "@/constant/socials";
 
 export const revalidate = 60;
 
@@ -36,6 +38,24 @@ export default async function NewHomePage() {
 
   return (
     <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "Organization",
+          name: "Bezold 頂讓必售",
+          url: process.env.NEXT_PUBLIC_APP_URL,
+          logo: `${process.env.NEXT_PUBLIC_APP_URL}/assets/bezold.png`,
+          sameAs: Object.values(SOCIAL_LINKS),
+        }}
+      />
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          name: "Bezold 頂讓必售",
+          url: process.env.NEXT_PUBLIC_APP_URL,
+        }}
+      />
       <LaunchBanner />
       <SiteNav />
       <div className={styles.frame}>

--- a/app/(new)/store-list/page.tsx
+++ b/app/(new)/store-list/page.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
   title: "Bezold 頂讓必售 — 我要找店",
   description:
     "瀏覽全台頂讓店面。依地區、行業、頂讓金快速篩選，直接聯絡賣家，沒有中間人。",
+  alternates: {
+    canonical: "/store-list",
+  },
 };
 
 interface PageProps {

--- a/app/(new)/store/[storeId]/page.tsx
+++ b/app/(new)/store/[storeId]/page.tsx
@@ -8,6 +8,7 @@ import StoreGallery from "./_components/StoreGallery";
 import StoreTitleRow from "./_components/StoreTitleRow";
 import StoreDescription from "./_components/StoreDescription";
 import StorePriceCard from "./_components/StorePriceCard";
+import JsonLd from "@/app/(new)/_components/JsonLd";
 import styles from "./page.module.css";
 
 interface StorePageProps {
@@ -20,14 +21,21 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const { storeId } = await params;
   const store = await getStoreById(storeId);
+  const canonicalUrl = `${process.env.NEXT_PUBLIC_APP_URL}/store/${storeId}`;
 
   if (!store) {
     return {
       title: "Bezold 頂讓必售 — 找不到物件",
+      alternates: {
+        canonical: canonicalUrl,
+      },
       openGraph: {
         title: "Bezold 頂讓必售 — 找不到物件",
         description: "此物件不存在或已下架",
-        url: `${process.env.NEXT_PUBLIC_APP_URL}/store/${storeId}`,
+        url: canonicalUrl,
+        siteName: "Bezold 頂讓必售",
+        type: "website",
+        locale: "zh_TW",
         images: ["/assets/bezold.png"],
       },
     };
@@ -35,10 +43,16 @@ export async function generateMetadata(
 
   return {
     title: `Bezold 頂讓必售 — ${store.storeName}`,
+    alternates: {
+      canonical: canonicalUrl,
+    },
     openGraph: {
       title: `Bezold 頂讓必售 — ${store.storeName}`,
       description: store.description,
-      url: `${process.env.NEXT_PUBLIC_APP_URL}/store/${storeId}`,
+      url: canonicalUrl,
+      siteName: "Bezold 頂讓必售",
+      type: "website",
+      locale: "zh_TW",
       images: store.images.length ? store.images : ["/assets/bezold.png"],
     },
   };
@@ -54,6 +68,23 @@ export default async function StoreDetailPage({ params }: StorePageProps) {
 
   return (
     <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "Product",
+          name: store.storeName,
+          description: store.description,
+          image: store.images.length ? store.images : ["/assets/bezold.png"],
+          url: `${process.env.NEXT_PUBLIC_APP_URL}/store/${storeId}`,
+          offers: {
+            "@type": "Offer",
+            priceCurrency: store.currency,
+            price: store.price,
+            availability: "https://schema.org/InStock",
+            url: `${process.env.NEXT_PUBLIC_APP_URL}/store/${storeId}`,
+          },
+        }}
+      />
       <LaunchBanner />
       <SiteNav activeLink="我要找店" />
       <main className={styles.main}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,9 +15,26 @@ const notoSansTC = Noto_Sans_TC({
   variable: "--font-noto-sans-tc",
 });
 
+const SITE_TITLE = "Bezold 頂讓必售 — 找一間準備好的店";
+const SITE_DESCRIPTION =
+  "全台店面頂讓平台。買家直接接手已有客群、設備、營運的店面；賣家把心血交給合適的人。早鳥前 3 個月免費刊登，永久不抽成。";
+
 export const metadata: Metadata = {
-  title: "Bezold",
-  description: "get to startup right now",
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL!),
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    siteName: "Bezold 頂讓必售",
+    type: "website",
+    locale: "zh_TW",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    images: ["/assets/bezold.png"],
+  },
 };
 
 export default function RootLayout({
@@ -27,7 +44,7 @@ export default function RootLayout({
 }) {
   return (
     <html
-      lang="en"
+      lang="zh-Hant"
       className={`${notoSansMono.variable} ${notoSansTC.variable} font-noto`}
     >
       <body>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL!;
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin", "/api", "/my-listings", "/login", "/signup"],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,51 @@
+import type { MetadataRoute } from "next";
+import { db } from "@/firebase/server";
+import { COLLECTIONS } from "@/firebase/constants";
+import { STORE_STATUS } from "@/types";
+
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL!;
+
+type ChangeFrequency = NonNullable<
+  MetadataRoute.Sitemap[number]["changeFrequency"]
+>;
+
+const route = (
+  path: string,
+  changeFrequency: ChangeFrequency,
+  priority: number,
+): MetadataRoute.Sitemap[number] => ({
+  url: `${BASE_URL}${path}`,
+  changeFrequency,
+  priority,
+});
+
+const STATIC_ROUTES: MetadataRoute.Sitemap = [
+  route("/", "daily", 1),
+  route("/store-list", "daily", 0.9),
+  route("/sell", "weekly", 0.8),
+  route("/faq", "monthly", 0.5),
+  route("/store-guide", "monthly", 0.5),
+  route("/privacy", "yearly", 0.3),
+  route("/terms", "yearly", 0.3),
+  route("/login", "yearly", 0.2),
+  route("/signup", "yearly", 0.2),
+];
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const snapshot = await db
+    .collection(COLLECTIONS.STORE)
+    .where("status", "==", STORE_STATUS.APPROVED)
+    .get();
+
+  const storeRoutes: MetadataRoute.Sitemap = snapshot.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      url: `${BASE_URL}/store/${doc.id}`,
+      lastModified: data.updateTime?.toDate?.() ?? new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    };
+  });
+
+  return [...STATIC_ROUTES, ...storeRoutes];
+}


### PR DESCRIPTION
## Summary
- Fix `<html lang="en">` → `lang="zh-Hant"` (site is Traditional-Chinese, Taiwan-targeted)
- Add `metadataBase`, branded root title/description, site-wide Open Graph defaults, and explicit `robots` directive in `app/layout.tsx`
- Add `app/sitemap.ts` (static routes + dynamic `/store/{storeId}` entries for approved listings) and `app/robots.ts`
- Add canonical URLs to `/store-list` and `/store/[storeId]` to consolidate query-string duplicate-content signals
- Extend Open Graph on store detail pages (`type`, `locale`, `siteName`)
- Add JSON-LD structured data via new `JsonLd` helper: `Organization`/`WebSite` schema on the home page, `Product`/`Offer` schema per store listing

Closes #35

## Test plan
- [x] `npm run build` — `/sitemap.xml` and `/robots.txt` appear as routes, no type errors
- [x] `npm run lint` — no new warnings/errors (only pre-existing unrelated warning in `admin/users/page.tsx`)
- [x] Verified in dev: `/sitemap.xml` lists all static + dynamic store URLs with correct `lastmod`/`changefreq`/`priority`; `/robots.txt` has correct allow/disallow rules and sitemap pointer
- [x] Viewed page source on `/`, `/store-list`, `/store/[storeId]` — confirmed `lang="zh-Hant"`, correct (non-duplicated) `<title>`, `og:*` tags, `<link rel="canonical">`, valid `<script type="application/ld+json">` blocks
- [x] `prettier --check` passes on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)