### PR TITLE
feat: Firebase Analytics — page views + conversion tracking

### DIFF
--- a/app/(new)/_components/HeroSplit/index.tsx
+++ b/app/(new)/_components/HeroSplit/index.tsx
@@ -1,5 +1,6 @@
 import styles from "./HeroSplit.module.css";
 import BuyerForm from "./BuyerForm";
+import SellCtaLink from "../SellCtaLink";
 
 export default function HeroSplit() {
   return (
@@ -49,9 +50,12 @@ export default function HeroSplit() {
             <li>5 分鐘填完刊登表</li>
             <li>上架，買家直接聯絡你</li>
           </ol>
-          <a href="/sell" className={`${styles.btn} ${styles.btnMus}`}>
+          <SellCtaLink
+            ctaLocation="hero"
+            className={`${styles.btn} ${styles.btnMus}`}
+          >
             立即免費刊登 →
-          </a>
+          </SellCtaLink>
         </div>
       </div>
     </section>

--- a/app/(new)/_components/SellButton.tsx
+++ b/app/(new)/_components/SellButton.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { auth } from "@/firebase/client";
+import { auth, trackEvent } from "@/firebase/client";
 import Button from "@/components/refactored/Button";
 
 export default function SellButton() {
   const router = useRouter();
 
   function handleClick() {
+    trackEvent("sell_cta_click", { cta_location: "nav" });
     if (auth.currentUser) {
       router.push("/sell");
     } else {

--- a/app/(new)/_components/SellCtaLink.tsx
+++ b/app/(new)/_components/SellCtaLink.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import NextLink from "next/link";
+import { trackEvent } from "@/firebase/client";
+
+/**
+ * Link for the "free listing" CTAs that fires a `sell_cta_click` analytics
+ * event before navigating. Uses NextLink for client-side navigation (no full
+ * unload), so the async event reliably fires. Use for plain-link CTAs (including
+ * inside server components); button-based CTAs call trackEvent from their
+ * onClick handler.
+ */
+export default function SellCtaLink({
+  ctaLocation,
+  href = "/sell",
+  className,
+  children,
+}: {
+  ctaLocation: string;
+  href?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <NextLink
+      href={href}
+      className={className}
+      onClick={() =>
+        trackEvent("sell_cta_click", { cta_location: ctaLocation })
+      }
+    >
+      {children}
+    </NextLink>
+  );
+}

--- a/app/(new)/_components/SellerCta.tsx
+++ b/app/(new)/_components/SellerCta.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { auth } from "@/firebase/client";
+import { auth, trackEvent } from "@/firebase/client";
 import Section from "./Section";
 import styles from "./SellerCta.module.css";
 import Button from "@/components/refactored/Button";
@@ -10,6 +10,7 @@ export default function SellerCta() {
   const router = useRouter();
 
   function handleSell() {
+    trackEvent("sell_cta_click", { cta_location: "seller_cta_section" });
     if (auth.currentUser) {
       router.push("/sell");
     } else {

--- a/app/(new)/my-listings/_components/MyListingsContent.tsx
+++ b/app/(new)/my-listings/_components/MyListingsContent.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { onAuthStateChanged } from "firebase/auth";
 import NextLink from "next/link";
-import { auth } from "@/firebase/client";
+import { auth, trackEvent } from "@/firebase/client";
 import { getStoresByUserId } from "@/firebase/clientUtils";
 import type { Store } from "@/types";
 import ListingCard from "./ListingCard";
@@ -43,7 +43,13 @@ export default function MyListingsContent() {
     return (
       <div className={styles.empty}>
         <p className={styles.emptyText}>你還沒有刊登任何店面</p>
-        <NextLink href="/sell" className={styles.emptyLink}>
+        <NextLink
+          href="/sell"
+          className={styles.emptyLink}
+          onClick={() =>
+            trackEvent("sell_cta_click", { cta_location: "my_listings_empty" })
+          }
+        >
           立即免費刊登 →
         </NextLink>
       </div>

--- a/app/(new)/sell/_components/SellForm.tsx
+++ b/app/(new)/sell/_components/SellForm.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { onAuthStateChanged } from "firebase/auth";
 import type { User as FirebaseUser } from "firebase/auth";
-import { auth } from "@/firebase/client";
+import { auth, trackEvent } from "@/firebase/client";
 import {
   getUserById,
   editUserById,
@@ -155,6 +155,11 @@ export default function SellForm() {
         ...(store.equipment ? { equipment: store.equipment } : {}),
       };
       const storeRef = await createStoreDoc(storePayload as unknown as Store);
+      trackEvent("store_listing_submit", {
+        store_id: storeRef.id,
+        category: store.category || "unspecified",
+        city: store.city || "unspecified",
+      });
       setCreatedStoreId(storeRef.id);
     } catch {
       setError("刊登店面失敗，請稍後再試");

--- a/app/(new)/signup/_components/SignupForm.tsx
+++ b/app/(new)/signup/_components/SignupForm.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createUserWithEmailAndPassword } from "firebase/auth";
 import { doc, setDoc, serverTimestamp } from "firebase/firestore";
-import { auth, db } from "@/firebase/client";
+import { auth, db, trackEvent } from "@/firebase/client";
 import { COLLECTIONS } from "@/firebase/constants";
 import Button from "@/components/refactored/Button";
 import Card from "@/components/refactored/Card";
@@ -80,6 +80,7 @@ export default function SignupForm() {
         createTime: serverTimestamp(),
         updateTime: serverTimestamp(),
       });
+      trackEvent("sign_up", { method: "email" });
       router.push("/store-list");
     } catch (err) {
       const code = (err as { code?: string }).code ?? "";

--- a/app/(new)/store-example/_components/ExampleBanner.tsx
+++ b/app/(new)/store-example/_components/ExampleBanner.tsx
@@ -1,12 +1,13 @@
 import styles from "./ExampleBanner.module.css";
+import SellCtaLink from "../../_components/SellCtaLink";
 
 export default function ExampleBanner() {
   return (
     <div className={styles.banner}>
       <span>這是示範頁面，非真實物件</span>
-      <a href="/sell" className={styles.cta}>
+      <SellCtaLink ctaLocation="store_example_banner" className={styles.cta}>
         立即免費刊登 →
-      </a>
+      </SellCtaLink>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,11 @@
 import "./globals.css";
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { Noto_Sans_Mono, Noto_Sans_TC } from "next/font/google";
 import { AntdRegistry } from "@ant-design/nextjs-registry";
 import { ConfigProvider } from "antd";
 import { Provider } from "jotai";
+import AnalyticsTracker from "@/components/AnalyticsTracker";
 
 const notoSansMono = Noto_Sans_Mono({
   subsets: ["latin"],
@@ -48,6 +50,9 @@ export default function RootLayout({
       className={`${notoSansMono.variable} ${notoSansTC.variable} font-noto`}
     >
       <body>
+        <Suspense fallback={null}>
+          <AnalyticsTracker />
+        </Suspense>
         <Provider>
           <AntdRegistry>
             <ConfigProvider

--- a/components/AnalyticsTracker.tsx
+++ b/components/AnalyticsTracker.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { logEvent } from "firebase/analytics";
+import { getAnalyticsClient } from "@/firebase/client";
+
+// Route prefixes that should never be tracked (admin dashboard, etc.).
+const UNTRACKED_PREFIXES = ["/admin"];
+
+const isUntracked = (pathname: string) =>
+  UNTRACKED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+
+/**
+ * Fires a GA4 `page_view` on every client-side route change. The App Router does
+ * not emit page views automatically, so this must be mounted once in the root
+ * layout (inside a <Suspense> boundary, since useSearchParams opts into CSR).
+ *
+ * Admin routes are excluded — we never send analytics for them.
+ */
+export default function AnalyticsTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (isUntracked(pathname)) return;
+
+    const query = searchParams.toString();
+    const pagePath = query ? `${pathname}?${query}` : pathname;
+
+    getAnalyticsClient().then((client) => {
+      if (!client) return;
+      logEvent(client, "page_view", {
+        page_path: pagePath,
+        page_location: window.location.href,
+        page_title: document.title,
+      });
+    });
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/docs/analytics-events.md
+++ b/docs/analytics-events.md
@@ -1,0 +1,75 @@
+# Analytics Events
+
+## Overview
+
+The site uses **Firebase Analytics (GA4)**. Initialization is browser-only and
+lazy — see [`firebase/client.ts`](../firebase/client.ts) (`getAnalyticsClient`,
+`trackEvent`). Page views are sent automatically by
+[`components/AnalyticsTracker.tsx`](../components/AnalyticsTracker.tsx), mounted
+once in the root layout. All custom events go through the `trackEvent()` helper,
+which safely no-ops on the server and on unsupported browsers.
+
+---
+
+## Event reference
+
+| Event                  | When it fires                                                           | Parameters                                 | Fired from                                                           |
+| ---------------------- | ----------------------------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
+| `page_view`            | Every client-side route change (App Router). Excludes `/admin/*`.       | `page_path`, `page_location`, `page_title` | [`AnalyticsTracker.tsx`](../components/AnalyticsTracker.tsx)         |
+| `sell_cta_click`       | User clicks any "免費刊登" CTA                                          | `cta_location`                             | See CTA table below                                                  |
+| `store_listing_submit` | A store listing is **successfully created** (after the Firestore write) | `store_id`, `category`, `city`             | [`SellForm.tsx`](<../app/(new)/sell/_components/SellForm.tsx>)       |
+| `sign_up`              | An account is **successfully created** (auth + user doc)                | `method` (`"email"`)                       | [`SignupForm.tsx`](<../app/(new)/signup/_components/SignupForm.tsx>) |
+
+> Conversion events (`store_listing_submit`, `sign_up`) fire **only on success**,
+> so failed or invalid attempts are not counted.
+
+### `sell_cta_click` — `cta_location` values
+
+| `cta_location`         | Placement                         | Component                                                                               |
+| ---------------------- | --------------------------------- | --------------------------------------------------------------------------------------- |
+| `nav`                  | Nav bar "＋ 限時免費刊登" button  | [`SellButton.tsx`](<../app/(new)/_components/SellButton.tsx>)                           |
+| `hero`                 | Homepage hero "立即免費刊登" link | [`HeroSplit/index.tsx`](<../app/(new)/_components/HeroSplit/index.tsx>)                 |
+| `seller_cta_section`   | "搶早鳥免費刊登" section button   | [`SellerCta.tsx`](<../app/(new)/_components/SellerCta.tsx>)                             |
+| `store_example_banner` | Store-example page banner link    | [`ExampleBanner.tsx`](<../app/(new)/store-example/_components/ExampleBanner.tsx>)       |
+| `my_listings_empty`    | My-listings empty-state link      | [`MyListingsContent.tsx`](<../app/(new)/my-listings/_components/MyListingsContent.tsx>) |
+
+Plain-link CTAs use the shared [`SellCtaLink`](<../app/(new)/_components/SellCtaLink.tsx>)
+component (NextLink + `trackEvent`). The two auth-branching buttons
+(`SellButton`, `SellerCta`) call `trackEvent` inline in their click handlers,
+since they route to `/sell` or `/login?redirect=/sell` depending on auth state.
+
+---
+
+## Adding a new event
+
+1. Call `trackEvent("event_name", { ...params })` from a client component,
+   ideally at the point the action **succeeds** (not on raw click) for
+   conversions.
+2. Use `snake_case` event and parameter names.
+3. Add a row to the reference table above.
+
+---
+
+## Dev / prod separation
+
+Both environments share one measurement ID. Dev vs prod is separated **in GA4
+reports** using the built-in **Hostname** dimension:
+
+- `hostname = localhost` → development
+- `hostname = <your domain>` → production
+
+Add a report comparison/filter on Hostname (exclude `localhost` to see prod
+only). No code or env changes are required for this.
+
+---
+
+## GA4 console setup (not code)
+
+- **Key events (重要活動):** mark `sign_up` and `store_listing_submit` as key
+  events (Admin → Key events) so they count as conversions.
+- **Custom dimensions:** to break reports down by `cta_location`, `category`, or
+  `city`, register each as an event-scoped custom dimension
+  (Admin → Custom definitions). Events still record without this; the params
+  just won't be available as report dimensions until registered.
+- **DebugView:** use Admin → DebugView (or the Realtime report) to confirm event
+  names and parameters arrive exactly as expected.

--- a/firebase/client.ts
+++ b/firebase/client.ts
@@ -2,6 +2,12 @@ import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 import { getAuth } from "firebase/auth";
+import {
+  getAnalytics,
+  isSupported,
+  logEvent,
+  type Analytics,
+} from "firebase/analytics";
 import { clientConfig } from "./configs";
 
 const app = initializeApp(clientConfig, "bezold client");
@@ -9,3 +15,24 @@ const app = initializeApp(clientConfig, "bezold client");
 export const db = getFirestore(app);
 export const storage = getStorage(app);
 export const auth = getAuth(app);
+
+// Analytics touches window/document/indexedDB synchronously, so it must not run
+// during SSR/build. Initialize it lazily and only in a supported browser.
+let analytics: Analytics | null = null;
+export const getAnalyticsClient = async (): Promise<Analytics | null> => {
+  if (typeof window === "undefined") return null;
+  if (analytics) return analytics;
+  if (!(await isSupported())) return null;
+  analytics = getAnalytics(app);
+  return analytics;
+};
+
+// Fire a custom analytics event; safely no-ops on the server / unsupported browsers.
+export const trackEvent = async (
+  name: string,
+  params?: Record<string, unknown>,
+): Promise<void> => {
+  const client = await getAnalyticsClient();
+  if (!client) return;
+  logEvent(client, name, params);
+};


### PR DESCRIPTION
## Summary

Adds Firebase (GA4) Analytics across the site with an SSR-safe setup, automatic page-view tracking, and conversion events for the key funnel actions.

## Changes

**Core setup**
- `firebase/client.ts` — analytics init is now **lazy and browser-only** (guarded by `typeof window` + `isSupported()`), fixing SSR/build crashes from the previous top-level `getAnalytics()`. Adds a `trackEvent()` helper that safely no-ops on the server / unsupported browsers.
- `components/AnalyticsTracker.tsx` — client component firing `page_view` on every App Router route change (mounted once in the root layout inside `<Suspense>`). **`/admin` routes are excluded** — analytics never initializes there.

**Conversion events** (all fire only on success, so failed/invalid attempts aren't counted)
- `sell_cta_click` (param `cta_location`) — every "免費刊登" CTA, via a reusable `SellCtaLink` (NextLink + trackEvent) plus the two auth-branching buttons.
- `store_listing_submit` (params `store_id`, `category`, `city`) — after a store doc is created in `SellForm`.
- `sign_up` (GA4 recommended event, param `method: email`) — after successful account creation in `SignupForm`.

## Dev/prod separation
Single shared measurement ID; dev vs prod is separated in GA4 reports by the **Hostname** dimension (`localhost` = dev). No env changes required.

## Follow-up (GA4 console, no code)
- Mark `sign_up` and `store_listing_submit` as **key events**.
- Optionally register `cta_location` / `category` / `city` as custom dimensions to break down reports.

## Verification
- Prettier + lint clean on all files.
- Verified in dev preview: pages render without SSR errors, analytics initializes client-side, admin routes skip init entirely, CTA links navigate correctly. Actual GA event delivery confirmed earlier via real GA4 realtime/DebugView (`page_view` from Taiwan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)