### PR TITLE
fix(build): eliminate dev-server warnings

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["storage.googleapis.com", "firebasestorage.googleapis.com"],
+    remotePatterns: [
+      { protocol: "https", hostname: "storage.googleapis.com" },
+      { protocol: "https", hostname: "firebasestorage.googleapis.com" },
+    ],
     minimumCacheTTL: 1500000, // * TODO: need more knowledge about this setting
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2657,9 +2657,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001636",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
-      "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2673,7 +2673,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/catharsis": {
       "version": "0.9.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    "tailwindcss/nesting": {},
     tailwindcss: {},
     autoprefixer: {},
   },


### PR DESCRIPTION
## Summary
Clears every warning emitted by `npm run dev` (verified: a clean `.next/cache` run now produces 0 warnings across all routes).

## Changes
| Warning | Fix |
| --- | --- |
| `Nested CSS was detected, but CSS nesting has not been configured correctly` (228×) | Added `tailwindcss/nesting` to `postcss.config.js` **before** `tailwindcss`, per [Tailwind docs](https://tailwindcss.com/docs/using-with-preprocessors#nesting). No new dependency — ships with tailwind 3.3.3. |
| `[webpack.cache.PackFileCacheStrategy] … No serializer registered for Warning` (~40×) | Downstream symptom of the above; resolved transitively. |
| `Browserslist: caniuse-lite is outdated` | Ran `npx update-browserslist-db@latest` (refreshes `package-lock.json`). |
| `images.domains configuration is deprecated` | Replaced `images.domains` with `images.remotePatterns` in `next.config.js` (1:1 mapping, `https` pinned for both Firebase/GCS hosts). |

## Test plan
- [x] `npm run dev` with cleared `.next/cache` → **0** warnings, all routes (`/`, `/store-list`, `/sell`, `/faq`, `/my-listings`, `/blog`) compile cleanly.
- [x] Config parses without the `images.domains` deprecation notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)