### PR TITLE
feat(home): add beehiiv newsletter signup section

### DIFF
--- a/app/(new)/_components/Newsletter.module.css
+++ b/app/(new)/_components/Newsletter.module.css
@@ -1,0 +1,47 @@
+.band {
+  border: 2px solid var(--ink);
+  border-radius: 6px;
+  background: var(--accent-3);
+  padding: 28px 32px;
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 32px;
+  align-items: center;
+  box-shadow: 5px 5px 0 var(--ink);
+  position: relative;
+}
+
+.copy h3 {
+  font-family: var(--display);
+  font-size: 32px;
+  margin: 0;
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--ink);
+}
+
+.copy p {
+  font-family: var(--hand);
+  font-size: 13px;
+  margin: 10px 0 0;
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+
+.form {
+  width: 100%;
+  /* Reserve the single-row form height so the band doesn't reflow when the
+     beehiiv iframe finishes loading and paints in. */
+  min-height: 56px;
+}
+
+.form iframe {
+  width: 100% !important;
+}
+
+@media (max-width: 900px) {
+  .band {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+}

--- a/app/(new)/_components/Newsletter.tsx
+++ b/app/(new)/_components/Newsletter.tsx
@@ -51,7 +51,7 @@ export default function Newsletter() {
     <Section variant="alt">
       <div ref={bandRef} className={styles.band}>
         <div className={styles.copy}>
-          <h3>每週精選頂讓好店，第一手送進你的信箱</h3>
+          <h3>每週頂讓、創業資訊，第一手送進你的信箱</h3>
           <p>
             訂閱 Bezold
             週報，搶先掌握本週新上架的頂讓與轉讓商機。一週一封，隨時可取消訂閱。

--- a/app/(new)/_components/Newsletter.tsx
+++ b/app/(new)/_components/Newsletter.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { trackEvent } from "@/firebase/client";
+import Section from "./Section";
+import styles from "./Newsletter.module.css";
+
+const BEEHIIV_FORM_ID = "8c308b72-2740-45dc-aa85-f482da8d1c69";
+const BEEHIIV_LOADER = "https://subscribe-forms.beehiiv.com/v3/loader.js";
+
+export default function Newsletter() {
+  const formRef = useRef<HTMLDivElement>(null);
+
+  // React does not execute <script> tags rendered in JSX, so the beehiiv
+  // loader must be injected imperatively. It reads data-beehiiv-form and
+  // renders the form inside this container.
+  useEffect(() => {
+    const container = formRef.current;
+    if (!container || container.querySelector("script")) return;
+
+    const script = document.createElement("script");
+    script.src = BEEHIIV_LOADER;
+    script.async = true;
+    script.setAttribute("data-beehiiv-form", BEEHIIV_FORM_ID);
+    container.appendChild(script);
+  }, []);
+
+  // Fire once when the section scrolls into view, giving us the impression
+  // count to pair with beehiiv's own subscribe numbers for a conversion rate.
+  // The submit itself happens inside beehiiv's cross-origin iframe, so it
+  // can't be tracked from here — beehiiv's dashboard is the source of truth.
+  const bandRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const band = bandRef.current;
+    if (!band) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          trackEvent("newsletter_view", { location: "home_after_hero" });
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.4 },
+    );
+    observer.observe(band);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Section variant="alt">
+      <div ref={bandRef} className={styles.band}>
+        <div className={styles.copy}>
+          <h3>每週精選頂讓好店，第一手送進你的信箱</h3>
+          <p>
+            訂閱 Bezold
+            週報，搶先掌握本週新上架的頂讓與轉讓商機。一週一封，隨時可取消訂閱。
+          </p>
+        </div>
+        <div ref={formRef} className={styles.form} />
+      </div>
+    </Section>
+  );
+}

--- a/app/(new)/_components/Newsletter.tsx
+++ b/app/(new)/_components/Newsletter.tsx
@@ -51,7 +51,7 @@ export default function Newsletter() {
     <Section variant="alt">
       <div ref={bandRef} className={styles.band}>
         <div className={styles.copy}>
-          <h3>每週頂讓、創業資訊，第一手送進你的信箱</h3>
+          <h3>每週頂讓、創業資訊，送進你的信箱</h3>
           <p>
             訂閱 Bezold
             週報，搶先掌握本週新上架的頂讓與轉讓商機。一週一封，隨時可取消訂閱。

--- a/app/(new)/page.tsx
+++ b/app/(new)/page.tsx
@@ -3,6 +3,7 @@ import styles from "./page.module.css";
 import LaunchBanner from "./_components/LaunchBanner";
 import SiteNav from "./_components/SiteNav";
 import HeroSplit from "./_components/HeroSplit";
+import Newsletter from "./_components/Newsletter";
 import TrustBar from "./_components/TrustBar";
 import FeaturedListings from "./_components/FeaturedListings";
 import Categories from "./_components/Categories";
@@ -43,6 +44,15 @@ export default async function NewHomePage() {
 
   return (
     <>
+      {/* Warm the beehiiv connection and start downloading the subscribe-form
+          loader during initial HTML parse, so it's cached by the time the
+          Newsletter section mounts it — cuts the first-load lag. */}
+      <link rel="preconnect" href="https://subscribe-forms.beehiiv.com" />
+      <link
+        rel="preload"
+        as="script"
+        href="https://subscribe-forms.beehiiv.com/v3/loader.js"
+      />
       <JsonLd
         data={{
           "@context": "https://schema.org",
@@ -77,6 +87,7 @@ export default async function NewHomePage() {
       <SiteNav />
       <div className={styles.frame}>
         <HeroSplit />
+        <Newsletter />
         {/* <TrustBar /> */}
         <FeaturedListings
           stores={highlightedStores}


### PR DESCRIPTION
## What

Adds a **每週頂讓週報** newsletter signup section on the homepage, right after the hero, embedding the beehiiv v3 subscribe form.

## Details

- **New section** ([Newsletter.tsx](app/(new)/_components/Newsletter.tsx)) — on-brand `--accent-3` band with heading + subtext (`每週精選頂讓好店，第一手送進你的信箱`) on the left and the beehiiv form on the right; stacks on mobile. Follows the no-number band pattern of `SellerCta` so it doesn't disturb the `01/02/03…` section numbering.
- **Loader injection** — the beehiiv loader is injected imperatively via a ref in `useEffect`, because React does not execute `<script>` tags rendered in JSX (they'd silently no-op).
- **Analytics** — fires `newsletter_view` via `IntersectionObserver` when the section scrolls into view (impression count to pair with beehiiv's own subscribe numbers). The submit itself happens inside beehiiv's cross-origin iframe and can't be tracked from our side.
- **First-load speed** — `preconnect` + `preload` resource hints for `subscribe-forms.beehiiv.com` in `page.tsx` warm the connection and pre-download the loader, cutting the cold-start lag. `.form` reserves `min-height` so the band doesn't reflow when the iframe paints.

## Verified

Renders correctly on desktop (two-column) and mobile (stacked); loader + iframe mount with no console errors.

## Follow-ups (beehiiv dashboard, not code)

- Redirect the public pub site `bezoldtw.beehiiv.com → bezold.com` so it doesn't compete with the SEO blog.
- Enable double opt-in + PDPA consent on the form.
- The actual weekly digest send — the whole point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)