### PR TITLE
fix: newsletter mobile width + store-list stale filter results

### DIFF
--- a/app/(new)/_components/Newsletter.module.css
+++ b/app/(new)/_components/Newsletter.module.css
@@ -45,3 +45,15 @@
     gap: 20px;
   }
 }
+
+/* On phones the beehiiv iframe keeps the email input and subscribe button on
+   one row, so it needs ~304px of width or "立即訂閱" wraps to two lines. The
+   band's default padding plus the Section padding starves it below that, so
+   here we trim the padding and let the band bleed slightly into the Section
+   padding (negative inline margin) to reclaim width down to ~360px viewports. */
+@media (max-width: 560px) {
+  .band {
+    margin-inline: -18px;
+    padding: 24px 16px;
+  }
+}

--- a/app/(new)/store-list/_components/SearchBar.tsx
+++ b/app/(new)/store-list/_components/SearchBar.tsx
@@ -67,6 +67,11 @@ export default function SearchBar() {
     }
     startTransition(() => {
       router.push(`/store-list?${params.toString()}`);
+      // The App Router client cache is keyed by pathname, not searchParams, so
+      // navigating between filtered variants of /store-list can reuse a stale
+      // RSC payload (e.g. arriving from home's tag=RECOMMENDED link). refresh()
+      // forces the server component to re-run with the new params.
+      router.refresh();
     });
   };
 


### PR DESCRIPTION
## Summary

Two mobile/filtering bug fixes for the primary site.

### 1. Newsletter signup — mobile button wrapping
The newsletter form is a beehiiv **cross-origin iframe**, so its internal layout (email input + subscribe button on one row) can't be styled from our CSS — the only lever we control is the iframe's width. On phones the iframe was only ~276px, squeezing the `立即訂閱` button onto two lines.

Fix (scoped to the newsletter band, mobile only): trim the band padding and let it bleed slightly into the `Section` padding via a negative inline margin, reclaiming width down to ~360px viewports (iframe width ≈ `viewport − 56`). No horizontal overflow — the negative margin stays within the section padding.

### 2. Store-list — stale results after clearing filters
Clearing filters and pressing Search kept showing the old filtered data when arriving via the home page's 編輯精選 → 看全部 link (`/store-list?tag=RECOMMENDED`).

Root cause: the App Router **client Router Cache is keyed by pathname, not `searchParams`**, so `router.push('/store-list')` reused the stale `tag=RECOMMENDED` RSC payload. Fix: call `router.refresh()` after the push to force the server component to re-run with the new params.

## Testing
- Newsletter: verified in Chrome DevTools mobile emulation — button on one line, form 344px, no horizontal overflow.
- Store-list: reproduced the exact user path (home → 看全部 → 清除全部 → 搜尋); count went from a stale `共 3 間` to the correct `共 7 間` after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)